### PR TITLE
fix: enhancement simplify and standardize template flags and naming conventions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,5 @@
 language: en-US
-tone_instructions: ""
+tone_instructions: "Focus on Go best practices, security for CLI tools, and operator-focused design. Emphasize offline-first capabilities and structured data handling."
 early_access: true
 enable_free_tier: true
 reviews:
@@ -9,7 +9,7 @@ reviews:
   high_level_summary_placeholder: "@coderabbitai summary"
   high_level_summary_in_walkthrough: true
   auto_title_placeholder: "@coderabbitai"
-  auto_title_instructions: ""
+  auto_title_instructions: "Use conventional commit format: <type>(<scope>): <description>"
   review_status: true
   commit_status: true
   fail_commit_status: false
@@ -48,7 +48,7 @@ reviews:
       threshold: 80
     title:
       mode: warning
-      requirements: ""
+      requirements: "Must follow conventional commit format"
     description:
       mode: warning
     issue_assessment:
@@ -62,11 +62,11 @@ reviews:
     shellcheck:
       enabled: true
     ruff:
-      enabled: true
+      enabled: false
     markdownlint:
       enabled: true
     github-checks:
-      enabled: true
+      enabled: false
       timeout_ms: 90000
     languagetool:
       enabled: true
@@ -77,18 +77,18 @@ reviews:
       enabled_only: false
       level: default
     biome:
-      enabled: true
+      enabled: false
     hadolint:
       enabled: true
     swiftlint:
-      enabled: true
+      enabled: false
     phpstan:
-      enabled: true
+      enabled: false
       level: default
     phpmd:
-      enabled: true
+      enabled: false
     phpcs:
-      enabled: true
+      enabled: false
     golangci-lint:
       enabled: true
     yamllint:
@@ -98,56 +98,56 @@ reviews:
     checkov:
       enabled: true
     detekt:
-      enabled: true
+      enabled: false
     eslint:
-      enabled: true
+      enabled: false
     flake8:
-      enabled: true
+      enabled: false
     rubocop:
-      enabled: true
+      enabled: false
     buf:
-      enabled: true
+      enabled: false
     regal:
-      enabled: true
+      enabled: false
     actionlint:
       enabled: true
     pmd:
-      enabled: true
+      enabled: false
     cppcheck:
-      enabled: true
+      enabled: false
     semgrep:
       enabled: true
     circleci:
       enabled: true
     clippy:
-      enabled: true
+      enabled: false
     sqlfluff:
-      enabled: true
+      enabled: false
     prismaLint:
-      enabled: true
+      enabled: false
     pylint:
-      enabled: true
+      enabled: false
     oxc:
-      enabled: true
+      enabled: false
     shopifyThemeCheck:
-      enabled: true
+      enabled: false
     luacheck:
-      enabled: true
+      enabled: false
     brakeman:
-      enabled: true
+      enabled: false
     dotenvLint:
       enabled: true
     htmlhint:
-      enabled: true
+      enabled: false
     checkmake:
       enabled: true
 chat:
   auto_reply: true
   integrations:
     jira:
-      usage: auto
+      usage: disabled
     linear:
-      usage: auto
+      usage: disabled
 knowledge_base:
   opt_out: false
   web_search:
@@ -160,10 +160,10 @@ knowledge_base:
   issues:
     scope: auto
   jira:
-    usage: auto
+    usage: disabled
     project_keys: []
   linear:
-    usage: auto
+    usage: disabled
     team_keys: []
   pull_requests:
     scope: auto

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,7 +66,7 @@ reviews:
     markdownlint:
       enabled: true
     github-checks:
-      enabled: false
+      enabled: true
       timeout_ms: 90000
     languagetool:
       enabled: true

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -14,7 +14,6 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.21, stable]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: test
     runs-on: ${{ matrix.os }}
@@ -25,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: stable
           check-latest: true
 
       - name: Install pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ dist/
 build/
 bin/
 
+# GoReleaser and packaging artifacts
+packaging/completions/
+packaging/*.1
+opndossier-temp
+
 # Go coverage and profiling
 coverage.txt
 *.cover

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,9 +7,23 @@ before:
   hooks:
     - go mod tidy
     - go generate ./...
+    - git-cliff --output CHANGELOG.md
+    # Build binary first for generating documentation
+    - go build -o ./opndossier-temp ./main.go
+    # Generate shell completions
+    - mkdir -p ./packaging/completions
+    - bash -c './opndossier-temp completion bash > ./packaging/completions/opndossier.bash'
+    - bash -c './opndossier-temp completion zsh > ./packaging/completions/opndossier.zsh'
+    - bash -c './opndossier-temp completion fish > ./packaging/completions/opndossier.fish'
+    - bash -c './opndossier-temp completion powershell > ./packaging/completions/opndossier.ps1'
+    # Generate man pages
+    - ./opndossier-temp man ./packaging/
+    # Clean up temporary binary
+    - rm ./opndossier-temp
 
 builds:
-  - binary: opnDossier
+  - binary: opndossier
+    main: ./main.go
     env:
       - CGO_ENABLED=0
     goos:
@@ -20,10 +34,14 @@ builds:
     goarch:
       - amd64
       - arm64
-    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X github.com/EvilBit-Labs/opnDossier/cmd.buildDate={{.Date}} -X github.com/EvilBit-Labs/opnDossier/cmd.gitCommit={{.Commit}}
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X github.com/EvilBit-Labs/opnDossier/cmd.buildDate={{.Date}} -X github.com/EvilBit-Labs/opnDossier/cmd.gitCommit={{.Commit}}
     ignore:
       - goos: freebsd
         goarch: arm64
+    flags:
+      - -trimpath
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
   - formats: tar.gz
@@ -43,21 +61,7 @@ archives:
       - CHANGELOG.md
 
 changelog:
-  sort: asc
-  use: github
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-  groups:
-    - title: Features
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
-      order: 0
-    - title: "Bug fixes"
-      regexp: '^.*?bug(\([[:word:]]+\))??!?:.+$'
-      order: 1
-    - title: Others
-      order: 999
+  disable: true
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
@@ -67,8 +71,56 @@ release:
     name: "opnDossier"
   prerelease: auto
   include_meta: true
+  header: |
+    ## Release {{.Tag}}
+
+    This release was built with Go {{.Env.GO_VERSION}} and includes the following changes:
+  footer: |
+
+    **Full Changelog**: https://github.com/EvilBit-Labs/opnDossier/compare/{{.PreviousTag}}...{{.Tag}}
+
+    ## Installation
+
+    ### Package Managers
+
+    **Debian/Ubuntu (.deb)**:
+    ```bash
+    wget https://github.com/EvilBit-Labs/opnDossier/releases/download/{{.Tag}}/opndossier_{{.Version}}_linux_amd64.deb
+    sudo dpkg -i opndossier_{{.Version}}_linux_amd64.deb
+    ```
+
+    **Red Hat/CentOS/Fedora (.rpm)**:
+    ```bash
+    wget https://github.com/EvilBit-Labs/opnDossier/releases/download/{{.Tag}}/opndossier_{{.Version}}_linux_amd64.rpm
+    sudo rpm -i opndossier_{{.Version}}_linux_amd64.rpm
+    ```
+
+    **Alpine (.apk)**:
+    ```bash
+    wget https://github.com/EvilBit-Labs/opnDossier/releases/download/{{.Tag}}/opndossier_{{.Version}}_linux_amd64.apk
+    sudo apk add --allow-untrusted opndossier_{{.Version}}_linux_amd64.apk
+    ```
+
+    **Arch Linux**:
+    ```bash
+    wget https://github.com/EvilBit-Labs/opnDossier/releases/download/{{.Tag}}/opndossier_{{.Version}}_linux_amd64.pkg.tar.xz
+    sudo pacman -U opndossier_{{.Version}}_linux_amd64.pkg.tar.xz
+    ```
+
+    ### Download Binary
+    Download the appropriate binary for your platform from the assets below.
+
+    ### Docker
+    ```bash
+    docker pull ghcr.io/evilbit-labs/opndossier:{{.Tag}}
+    ```
+
+    ### Verify Checksums
+    ```bash
+    sha256sum -c opnDossier_checksums.txt
+    ```
 source:
-  enabled: true
+  enabled: false
 universal_binaries:
   - replace: true
 
@@ -90,23 +142,6 @@ dockers:
       - "--label=org.opencontainers.image.source = 'https://github.com/EvilBit-Labs/opnDossier'"
       - "--build-arg=branch=latest"
       - "--platform=linux/amd64"
-  - image_templates:
-      - "ghcr.io/evilbit-labs/opndossier:{{ .Tag }}-pocl"
-      - "ghcr.io/evilbit-labs/opndossier:v{{ .Major }}-pocl"
-      - "ghcr.io/evilbit-labs/opndossier:v{{ .Major }}.{{ .Minor }}-pocl"
-      - "ghcr.io/evilbit-labs/opndossier:pocl"
-    use: buildx
-    dockerfile: Dockerfile.releaser
-    goarch: amd64
-    goos: linux
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source = 'https://github.com/EvilBit-Labs/opnDossier'"
-      - "--build-arg=branch=pocl"
-      - "--platform=linux/amd64"
 
 milestones:
   - repo:
@@ -114,8 +149,89 @@ milestones:
       name: opnDossier
     close: true
     fail_on_error: false
+nfpms:
+  - id: packages
+    package_name: opndossier
+    file_name_template: "{{ .ConventionalFileName }}"
+    vendor: EvilBit Labs
+    homepage: https://github.com/EvilBit-Labs/opnDossier
+    maintainer: EvilBit Labs <contact@evilbitlabs.io>
+    description: |
+      opnDossier is a command-line interface (CLI) tool designed to process OPNsense
+      firewall configuration files (config.xml) and convert them into human-readable
+      formats, primarily Markdown. This tool assists network administrators and
+      security professionals in documenting, auditing, and understanding their
+      OPNsense configurations more effectively.
+    license: MIT
+    section: utils
+    priority: optional
+    formats:
+      - deb
+      - rpm
+      - apk
+      - archlinux
+    dependencies:
+      - ca-certificates
+    recommends:
+      - git
+      - curl
+    suggests:
+      - bash-completion
+    bindir: /usr/bin
+    contents:
+      # Binary is automatically included by nfpm from the build output
+      # Documentation
+      - src: ./LICENSE
+        dst: /usr/share/doc/opndossier/LICENSE
+        file_info:
+          mode: 0644
+      - src: ./README.md
+        dst: /usr/share/doc/opndossier/README.md
+        file_info:
+          mode: 0644
+      - src: ./CHANGELOG.md
+        dst: /usr/share/doc/opndossier/CHANGELOG.md
+        file_info:
+          mode: 0644
+      # Man page
+      - src: ./packaging/opnDossier.1
+        dst: /usr/share/man/man1/opndossier.1
+        file_info:
+          mode: 0644
+      # Shell completions
+      - src: ./packaging/completions/opndossier.bash
+        dst: /usr/share/bash-completion/completions/opndossier
+        file_info:
+          mode: 0644
+      - src: ./packaging/completions/opndossier.zsh
+        dst: /usr/share/zsh/site-functions/_opndossier
+        file_info:
+          mode: 0644
+      - src: ./packaging/completions/opndossier.fish
+        dst: /usr/share/fish/vendor_completions.d/opndossier.fish
+        file_info:
+          mode: 0644
+    rpm:
+      group: Applications/System
+      compression: lzma
+      signature:
+        key_file: '{{ if index .Env "RPM_SIGNING_KEY_FILE" }}{{ .Env.RPM_SIGNING_KEY_FILE }}{{ end }}'
+    deb:
+      compression: xz
+      signature:
+        key_file: '{{ if index .Env "DEB_SIGNING_KEY_FILE" }}{{ .Env.DEB_SIGNING_KEY_FILE }}{{ end }}'
+    apk:
+      signature:
+        key_file: '{{ if index .Env "APK_SIGNING_KEY_FILE" }}{{ .Env.APK_SIGNING_KEY_FILE }}{{ end }}'
+    archlinux:
+      pkgbase: opndossier
+      packager: EvilBit Labs <contact@evilbitlabs.io>
+
 sboms:
-  - artifacts: archive
+  - id: archive-sbom
+    artifacts: archive
+  - id: package-sbom
+    artifacts: package
 notarize:
   macos:
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,350 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### 🚀 Features
+
+- *(security)* Add security policy documentation
+
+  - Introduced a new SECURITY.md file outlining the security policy, supported versions, vulnerability reporting process, responsible disclosure guidelines, and security best practices for opnFocus.
+  - Documented security features and provided contact information for security-related inquiries.
+
+- *(templates)* Add issue and pull request templates
+
+  - Introduced a new issue template for bug reports, feature requests, documentation issues, and general issues, providing a structured format for users to report problems and suggestions.
+  - Added a pull request template to guide contributors in providing clear descriptions, change types, related issues, testing procedures, and documentation updates.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(config)* Add new sample configuration files for OPNsense
+
+  - Introduced `sample.config.6.xml` and `sample.config.7.xml` files containing comprehensive configurations for OPNsense, including system settings, interface configurations, and firewall rules.
+  - The new configurations enhance the setup process and provide examples for various network setups.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add support for including system tunables in report generation
+
+  - Introduced a new CLI flag `--include-tunables` to allow users to include system tunables in the output report.
+  - Implemented a filtering function to conditionally include or exclude tunables based on their values.
+  - Updated report templates to display tunables correctly when the flag is set.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add initial configuration for CodeRabbit integration
+
+  - Introduced a new configuration file `.coderabbit.yaml` to set up CodeRabbit features and settings.
+  - Configured various options including auto review, chat integrations, and code generation settings.
+  - Enabled multiple linting tools and pre-merge checks to enhance code quality and review processes.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Implement embedded template functionality and testing
+
+  - Added support for embedding templates in the binary using Go's embed package, allowing the application to access templates even when filesystem templates are missing.
+  - Created tests to validate the embedded templates functionality, ensuring templates are accessible and correctly loaded.
+  - Updated the markdown package to utilize embedded templates, enhancing the template management system.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Enhance build tests for embedded templates
+
+  - Introduced a new test suite for validating the functionality of the binary with embedded templates, ensuring proper execution and accessibility.
+  - Updated existing tests to utilize the new suite structure, improving organization and maintainability.
+  - Disabled specific linters in the configuration to address compatibility issues with cobra commands.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add opnsense configuration DTD and update XSD schema
+
+  - Introduced a new DTD file for opnsense configuration, defining the structure and elements for XML configuration files.
+  - Updated the XSD schema to reflect changes in the configuration structure, including the addition of new elements and attributes.
+  - Removed deprecated elements and adjusted sequences to improve validation accuracy.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Enhance display options and add new utility functions
+
+  - Updated `buildDisplayOptions` to handle special template formats (json, yaml) by setting the format instead of the template name.
+  - Introduced new utility functions in `markdown/formatters.go` for boolean formatting and power mode descriptions.
+  - Updated template function map in `markdown/generator.go` to include new formatting functions.
+  - Adjusted various model fields to use integer types for better consistency and validation.
+  - Updated templates to utilize new formatting functions for improved output consistency.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add GitHub Actions workflow testing commands for Unix and Windows
+
+  - Introduced `act-workflow` commands in the `justfile` for testing GitHub Actions workflows on both Unix and Windows platforms.
+  - Added error handling to check for the presence of the `act` command and provide installation instructions if not found.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add utility functions for boolean evaluation and formatting
+
+  - Introduced `IsTruthy`, `FormatBoolean`, and `FormatBooleanWithUnset` functions to evaluate truthy values and format boolean representations.
+  - Added comprehensive unit tests for each function to ensure correct behavior across various input cases.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Refactor command flags and shared functionality for convert and display commands
+
+  - Consolidated shared flags for template, sections, theme, and wrap width into a new `shared_flags.go` file to reduce duplication.
+  - Updated the `convert` and `display` commands to utilize shared flags, improving maintainability.
+  - Disabled audit mode functionality temporarily, with appropriate comments and error handling in place.
+  - Enhanced test coverage for flag validation and command behavior.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+### 🐛 Bug Fixes
+
+- *(display)* Remove validation from display command by default
+
+  - Change display command to use Parse() instead of ParseAndValidate() by default
+  - Display command now only ensures XML can be unmarshalled into data model
+  - Full configuration quality validation remains in validate command only
+  - Update help text and flag descriptions to reflect new behavior
+  - Fixes issue #29 where display command incorrectly ran validation
+
+  This change allows display command to work with production configurations
+  that may have inconsistencies but are still valid for operating firewalls.
+
+- *(migration)* Update module path instructions in migration.md
+
+  - Changed the command for updating the `go.mod` file's module path from a sed command to Go's official `go mod edit` command for improved safety.
+  - Ensured clarity in the migration instructions for updating import paths in Go files.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(docs)* Update issue template and installation guide
+
+  - Modified the issue template to escape the Just version comment for clarity.
+  - Added a ConfigMap example and a Job example in the installation guide for Kubernetes, enhancing documentation for users.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(templates)* Update formatting for system notes in OPNsense report template
+
+  - Changed code block syntax for system notes to use `text` for better clarity.
+  - Updated fallback message for no system notes to maintain consistent formatting.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(tests)* Simplify markdown test assertions by removing ANSI stripping
+
+  - Removed the ANSI stripping function and adjusted assertions to work directly with markdown output, leveraging the `TERM=dumb` environment variable for consistent test results.
+  - Updated test cases to check for formatted output with bold labels for better clarity.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(tests)* Enhance config test assertions and output path handling
+
+  - Updated the temporary config file creation in `TestLoadConfigPrecedence` to use a valid output path.
+  - Adjusted assertions to verify the correct output file path based on the new configuration.
+  - Improved error message validation in `TestFileExporter` tests to account for platform-specific behavior.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(validate)* Display all validation errors instead of just the first one
+
+  - Update AggregatedValidationError.Error() to show all validation errors with numbered list
+  - Modify validate command to properly display all validation issues for each file
+  - Update tests to match new error message format
+  - Fixes issue #32 where only first validation error was shown
+
+- Standardize MTU field naming in VPN model and templates
+
+  - Changed the MTU field in the WireGuardServerItem struct from lowercase to uppercase for consistency.
+  - Updated the corresponding template to reflect the new field naming convention.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Standardize PSK field naming in VPN model and templates
+
+  - Changed the PSK field in the WireGuardClientItem struct from lowercase to uppercase for consistency.
+  - Updated the corresponding template to reflect the new field naming convention.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Improve number parsing in IsTruthy function
+
+  - Refactored the number parsing logic in the IsTruthy function to simplify the handling of both integer and float values.
+  - Updated comments for clarity regarding truthy evaluation of numbers.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+### 🚜 Refactor
+
+- Remove JSON and YAML template files and update related functionality
+
+  - Deleted unused `json_output.tmpl` and `yaml_output.tmpl` files to streamline template management.
+  - Updated the `generateJSON` and `generateYAML` methods to use direct marshaling instead of templates, simplifying the output generation process.
+  - Adjusted tests to reflect the removal of templates and updated expected values accordingly.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Simplify opnsense-config XSD schema by removing deprecated elements
+
+  - Removed multiple deprecated optional elements from the opnsense-config XSD schema to streamline the configuration structure.
+  - Introduced a new `xs:any` element to allow for additional interface names, enhancing flexibility for DHCP configuration.
+  - Updated the schema to reflect standard/reserved interface names while maintaining support for custom naming.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Refactor CI configuration and enhance testing workflow
+
+  - Renamed CI workflow from `ci-check` to `CI` for clarity and consistency.
+  - Consolidated testing steps into a single job with a matrix strategy for Go versions and OS platforms.
+  - Added a new `test-coverage` command in the Justfile to run tests with coverage reporting.
+  - Removed obsolete `ci.yml` file to streamline CI configuration.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(ci)* Add golangci-lint setup to CI workflow
+
+  - Integrated golangci-lint into the CI workflow for improved code quality checks.
+  - Configured the action to use the latest version for consistency.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(justfile)* Add full-checks command to streamline CI process
+
+  - Introduced a new `full-checks` command to run all checks, tests, and release validation in a single step.
+  - Updated the Justfile to include a call to `ci-check` and `check-goreleaser` for comprehensive validation.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(workflow)* Remove summary workflow for issue summarization
+
+  - Deleted the `.github/workflows/summary.yml` file, which contained a GitHub Actions workflow for summarizing new issues.
+  - This change cleans up the repository by removing an unused workflow.
+
+  No tests were affected by this change.
+
+- *(ci)* Simplify Go version matrix in CI workflow
+
+  - Removed the specific Go version `1.24` from the CI workflow matrix, retaining only `stable` for testing.
+  - This change streamlines the CI configuration and focuses on the latest stable Go version.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(workflow)* Remove summary workflow for issue summarization
+
+  - Deleted the `.github/workflows/summary.yml` file, which contained a GitHub Actions workflow for summarizing new issues.
+  - This change cleans up the repository by removing an unused workflow.
+
+  No tests were affected by this change.
+
+- *(ci)* Simplify Go version matrix in CI workflow
+
+  - Removed the specific Go version `1.24` from the CI workflow matrix, retaining only `stable` for testing.
+  - This change streamlines the CI configuration and focuses on the latest stable Go version.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add MIGRATION IN-PROGRESS notice to README.md
+  Temporarily freeze development during repository migration
+
+- Update compliance and project documentation for opnDossier
+
+  - Added comprehensive compliance standards documentation, including guidelines for compliance framework, audit engine architecture, and testing requirements.
+  - Updated project structure and naming conventions to reflect the transition from opnFocus to opnDossier.
+  - Revised documentation to ensure consistency across all project files and improve clarity.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Rename project from opnFocus to opnDossier and update documentation
+
+  - Updated project name and references from opnFocus to opnDossier across documentation and configuration files.
+  - Enhanced CoPilot instructions to reflect new project structure and guidelines.
+  - Adjusted CI workflow for new build outputs and Go version matrix.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update documentation to reflect project name change to opnDossier
+
+  - Renamed all instances of opnFocus to opnDossier in requirements, tasks, and user stories documentation.
+  - Ensured consistency across all project documentation to align with the new project name.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update project references and configurations for opnDossier
+
+  - Renamed all instances of opnFocus to opnDossier across various configuration files, documentation, and codebase.
+  - Updated .gitignore, .golangci.yml, .goreleaser.yaml, and other relevant files to reflect the new project name and structure.
+  - Added new XML schema for OPNsense configurations in testdata.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update documentation and configuration for opnDossier
+
+  - Replaced all instances of `OPNFOCUS` with `OPNDOSSIER` in various documentation files, including CONTRIBUTING.md, DEVELOPMENT_STANDARDS.md, and README.md.
+  - Updated environment variable references and configuration management details to reflect the new naming convention.
+  - Ensured consistency across all project documentation and examples.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update report templates to reflect project name change to opnDossier
+
+  - Replaced instances of opnFocus with opnDossier in opnsense_report_comprehensive.md.tmpl and opnsense_report.md.tmpl.
+  - Ensured consistency in the generated output across both report templates.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Rename project references from opnFocus to opnDossier
+
+  - Updated all instances of `opnFocus` to `opnDossier` across the codebase, including module names, test files, and comments.
+  - Ensured consistency in naming conventions throughout the project to reflect the new branding.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add CI and CodeQL badges to README.md
+
+  - Included CI and CodeQL badges in the README.md to enhance visibility of the project's continuous integration and code quality checks.
+  - This update improves the documentation by providing immediate feedback on the project's build status and security analysis.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Add CodeRabbit Pull Request Reviews badge to README.md
+
+  - Included a new badge for CodeRabbit Pull Request Reviews in the README.md to enhance visibility of code review processes.
+  - This update improves the documentation by providing additional context for contributors regarding code review practices.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update .gitignore and justfile for improved coverage reporting
+
+  - Enhanced .gitignore to include additional Go build artifacts, coverage files, and system-specific files for better project cleanliness.
+  - Updated justfile to streamline coverage testing commands and ensure consistent usage of coverage.txt.
+  - Modified CI workflow to use the latest version of the Codecov action and updated coverage report handling.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update CI workflow and justfile for testing improvements
+
+  - Removed coverage testing command from `justfile` and replaced it with a standard test command.
+  - Added a new job in the CI workflow to run tests and collect coverage, including setup steps for Go and Codecov integration.
+  - Deleted the obsolete `lint_report.json` file to clean up the repository.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update CI workflow to run tests across all packages
+
+  - Modified the CI workflow to run tests for all Go packages by changing the test command to `go test -coverprofile=coverage.txt ./...`.
+  - This change enhances test coverage reporting and ensures all packages are tested during the CI process.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- Update release workflow to include main branch
+
+  - Added the main branch to the release workflow triggers, ensuring that releases are initiated on pushes to the main branch as well as version tags.
+  - This change enhances the flexibility of the release process.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
 ## [1.0.0-rc1] - 2025-08-01
 
 ### 🚀 Features
@@ -125,9 +469,9 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- *(testdata)* Replace config.xml with opndossier-config.xsd and add sample configurations
+- *(testdata)* Replace config.xml with opnfocus-config.xsd and add sample configurations
 
-  - Deleted the outdated `config.xml` file and replaced it with `opndossier-config.xsd`, which defines the schema for OPNsense configurations.
+  - Deleted the outdated `config.xml` file and replaced it with `opnfocus-config.xsd`, which defines the schema for OPNsense configurations.
   - Added multiple sample configuration files (`sample.config.1.xml`, `sample.config.4.xml`, `sample.config.5.xml`) to demonstrate various settings and features.
   - Introduced a README.md file to document the purpose and usage of the test data files.
 
@@ -440,9 +784,9 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- *(docs)* Expand tasks for opnDossier CLI tool implementation
+- *(docs)* Expand tasks for opnFocus CLI tool implementation
 
-  - Added a comprehensive release roadmap for the opnDossier CLI tool, detailing tasks and features for versions 1.0, 1.1, and 1.2.
+  - Added a comprehensive release roadmap for the opnFocus CLI tool, detailing tasks and features for versions 1.0, 1.1, and 1.2.
   - Included critical tasks for the v1.0 release, such as refactoring CLI command structure, implementing a help system, and ensuring test coverage.
   - Outlined major features for future versions, focusing on audit reports and performance enhancements.
 
@@ -541,7 +885,7 @@ All notable changes to this project will be documented in this file.
 - *(goreleaser)* Enhance multi-platform build configuration and add Docker support
 
   - Updated `.goreleaser.yaml` to include FreeBSD as a target OS and refined ldflags for versioning and commit information.
-  - Introduced Dockerfile for building the opnDossier image and added Docker support in GoReleaser configuration.
+  - Introduced Dockerfile for building the opnFocus image and added Docker support in GoReleaser configuration.
   - Enhanced `justfile` with new commands for building and releasing snapshots and full releases.
   - Updated `.gitignore` to exclude the `dist/` directory and marked TASK-060 as complete in `tasks.md`, confirming comprehensive GoReleaser configuration.
 
@@ -701,7 +1045,7 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Update project documentation and configuration files for opnDossier
+- Update project documentation and configuration files for opnFocus
 
   - Removed .cursorrules file as it was no longer needed.
   - Added node_modules/ to .gitignore to prevent tracking of dependencies.
@@ -712,7 +1056,7 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Enhance project documentation for opnDossier
+- Enhance project documentation for opnFocus
 
   - Added related documentation section in AGENTS.md, linking to requirements, architecture, and development standards.
   - Updated requirements.md to remove checkboxes and improve readability.
@@ -720,16 +1064,16 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Update project documentation and structure for opnDossier
+- Update project documentation and structure for opnFocus
 
   - Updated AGENTS.md to reflect the new path for the requirements document and improved project structure clarity.
-  - Added project_spec/requirements.md to serve as the comprehensive requirements document for the opnDossier CLI tool.
+  - Added project_spec/requirements.md to serve as the comprehensive requirements document for the opnFocus CLI tool.
   - Enhanced DEVELOPMENT_STANDARDS.md to reference the new requirements document location.
   - Created project_spec/tasks.md and project_spec/user_stories.md to outline implementation tasks and user stories.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Update documentation and formatting for opnDossier
+- Update documentation and formatting for opnFocus
 
   - Improved formatting in AGENTS.md and DEVELOPMENT_STANDARDS.md for better readability.
   - Updated README.md with correct documentation links and installation instructions.
@@ -755,7 +1099,7 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Add comprehensive Copilot instructions for opnDossier project
+- Add comprehensive Copilot instructions for opnFocus project
 
 - *(validator)* Clean up comment formatting in `demo.go`
 
@@ -865,7 +1209,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚙️ Miscellaneous Tasks
 
-- Update golangci-lint configuration and justfile for opnDossier
+- Update golangci-lint configuration and justfile for opnFocus
 
   - Enhanced .golangci.yml with additional linters, settings, and configurations for improved code quality checks.
   - Modified justfile to update project name, streamline development commands, and improve formatting and linting processes.
@@ -873,7 +1217,7 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Update golangci-lint settings and enhance justfile for opnDossier
+- Update golangci-lint settings and enhance justfile for opnFocus
 
   - Added module path and extra rules to the golangci-lint configuration in .golangci.yml for improved linting.
   - Removed the check-ast hook from .pre-commit-config.yaml to streamline pre-commit checks.
@@ -881,7 +1225,7 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Update dependencies and refactor opnDossier CLI structure
+- Update dependencies and refactor opnFocus CLI structure
 
   - Upgraded Go version to 1.24.0 and updated toolchain to 1.24.5.
   - Replaced several dependencies with newer versions, including charmbracelet libraries for improved functionality.
@@ -891,15 +1235,15 @@ All notable changes to this project will be documented in this file.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
-- Update module path in go.mod for opnDossier
+- Update module path in go.mod for opnFocus
 
-  - Changed module path from `opnDossier` to `github.com/EvilBit-Labs/opnDossier` for consistency with repository structure.
+  - Changed module path from `opnFocus` to `github.com/unclesp1d3r/opnFocus` for consistency with repository structure.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
 - Update import paths to use the new module structure
 
-  - Changed import paths from `opnDossier` to `github.com/EvilBit-Labs/opnDossier` across multiple files for consistency with the updated module path.
+  - Changed import paths from `opnFocus` to `github.com/unclesp1d3r/opnFocus` across multiple files for consistency with the updated module path.
   - Added additional test cases in `markdown_test.go` to handle nil input and empty struct scenarios.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
@@ -965,7 +1309,7 @@ All notable changes to this project will be documented in this file.
 
   - Revised documentation to reflect the transition from `charmbracelet/fang` to `spf13/viper` for configuration management.
   - Added details about `charmbracelet/fang` for enhanced CLI experience in multiple files.
-  - Updated `.gitignore` to include `opnDossier`.
+  - Updated `.gitignore` to include `opnFocus`.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 
@@ -986,8 +1330,8 @@ All notable changes to this project will be documented in this file.
 - Add initial project configuration files for Go development
 
   - Created `.idea/golinter.xml` to configure Go linter settings with a custom config file.
-  - Added `.idea/modules.xml` to manage project modules, linking to the `opnDossier.iml` module file.
-  - Introduced `.idea/opnDossier.iml` for module configuration, enabling Go support and defining content roots.
+  - Added `.idea/modules.xml` to manage project modules, linking to the `opnFocus.iml` module file.
+  - Introduced `.idea/opnFocus.iml` for module configuration, enabling Go support and defining content roots.
   - Established `.idea/vcs.xml` for version control settings, mapping the project directory to Git.
 
   These files set up the development environment for Go projects within the IDE.
@@ -1042,6 +1386,14 @@ All notable changes to this project will be documented in this file.
 
   - Deleted unused `nfpms` configuration from `.goreleaser.yaml` to streamline the release process.
   - Removed `files.txt` as it contained outdated test file references.
+
+  Tested with `just test` and `just ci-check`, all checks passed successfully.
+
+- *(changelog)* Update to version 1.0.0-rc1 and document notable changes
+
+  - Updated CHANGELOG.md to reflect the release of version 1.0.0-rc1, detailing new features, enhancements, and fixes.
+  - Documented improvements in XMLParser security, logger initialization, configuration management, and validation features.
+  - Added comprehensive markdown generation capabilities and updated documentation for better clarity and usability.
 
   Tested with `just test` and `just ci-check`, all checks passed successfully.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,396 @@
+# Releasing opnDossier
+
+This document outlines the complete process for preparing and releasing a new version of opnDossier. The project uses GoReleaser for automated releases, git-cliff for changelog generation, and follows semantic versioning principles.
+
+## Overview
+
+The opnDossier release process is designed to be:
+
+- **Local-First**: All commands run locally using the justfile and GoReleaser
+- **Consistent**: Following conventional commits and semantic versioning
+- **Comprehensive**: Includes binaries, Docker images, checksums, and SBOMs
+- **Secure**: Includes macOS notarization and code signing when configured
+
+## Prerequisites
+
+Before starting a release, ensure you have:
+
+1. **Required Tools**:
+
+   - `git-cliff` installed (run `just install-git-cliff` if needed)
+   - `goreleaser` installed
+   - Proper GitHub permissions for the repository
+
+2. **Environment Setup**:
+
+   - `GITHUB_TOKEN` with appropriate permissions
+   - For macOS notarization (optional):
+     - `MACOS_SIGN_P12`
+     - `MACOS_SIGN_PASSWORD`
+     - `MACOS_NOTARY_ISSUER_ID`
+     - `MACOS_NOTARY_KEY_ID`
+     - `MACOS_NOTARY_KEY`
+
+3. **Clean Working Directory**:
+
+   ```bash
+   git status  # Should show no uncommitted changes
+   git pull origin main  # Ensure you're up to date
+   ```
+
+4. **Docker Login** (for pushing container images):
+
+   ```bash
+   echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+   ```
+
+## Release Process
+
+### Step 1: Pre-Release Validation
+
+1. **Run Full Test Suite**:
+
+   ```bash
+   just full-checks
+   ```
+
+   This runs:
+
+   - Code formatting checks (`just format-check`)
+   - Linting (`just lint`)
+   - All tests (`just test`)
+   - GoReleaser configuration validation (`just check-goreleaser`)
+
+2. **Test Release Build** (Optional but Recommended):
+
+   ```bash
+   just build-snapshot
+   ```
+
+   This creates a snapshot build without publishing to verify everything works.
+
+### Step 2: Update Changelog
+
+The project uses `git-cliff` with conventional commits to automatically generate changelogs.
+
+1. **Generate Changelog for Unreleased Changes**:
+
+   ```bash
+   just changelog-unreleased
+   ```
+
+2. **Review the Generated Changelog**:
+
+   - Open `CHANGELOG.md` and review the unreleased section
+   - Ensure all important changes are captured
+   - Verify that conventional commit formatting is working correctly
+
+3. **Generate Changelog for Specific Version** (if needed):
+
+   ```bash
+   just changelog-version v1.2.3
+   ```
+
+### Step 3: Version Tagging
+
+opnDossier follows semantic versioning (SemVer) with the format `vMAJOR.MINOR.PATCH`:
+
+- **MAJOR**: Incompatible API changes or breaking changes
+- **MINOR**: New functionality in a backwards compatible manner
+- **PATCH**: Backwards compatible bug fixes
+
+1. **Create Version Tag**:
+
+   ```bash
+   # Replace X.Y.Z with your version number
+   git tag vX.Y.Z
+   ```
+
+   Note: Don't push the tag yet - this will be done after the release is created.
+
+   Examples:
+
+   - `v1.0.0` - First stable release
+   - `v1.1.0` - New features added
+   - `v1.0.1` - Bug fixes only
+   - `v2.0.0-rc1` - Release candidate
+   - `v2.0.0-beta1` - Beta release
+
+### Step 4: Local Release
+
+All releases are performed locally using the justfile commands:
+
+1. **Login to GitHub Container Registry** (for Docker images):
+
+   ```bash
+   echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+   ```
+
+2. **Run the Release**:
+
+   ```bash
+   just release
+   ```
+
+   This runs `goreleaser release --clean` which:
+
+   - Dynamically generates shell completions (bash, zsh, fish, PowerShell) using Cobra
+   - Dynamically generates man pages for all commands using Cobra
+   - Builds binaries for all platforms (FreeBSD, Linux, macOS, Windows)
+   - Creates archives with proper naming and includes LICENSE, README.md, CHANGELOG.md
+   - Generates native packages (.deb, .rpm, .apk, .pkg.tar.xz) with nfpm including:
+     - Man pages in `/usr/share/man/man1/`
+     - Shell completions for bash, zsh, and fish
+     - Complete documentation
+   - Generates checksums file (`opnDossier_checksums.txt`)
+   - Creates Software Bill of Materials (SBOM) for archives and packages
+   - Builds and pushes Docker images to GitHub Container Registry
+   - Creates the GitHub release with all artifacts attached
+   - Uses git-cliff generated changelog for release notes
+
+3. **Push the Git Tag** (after successful release):
+
+   ```bash
+   git push origin vX.Y.Z
+   ```
+
+### Alternative: Snapshot Release
+
+For testing the release process without publishing:
+
+```bash
+just release-snapshot
+```
+
+This creates all artifacts locally but doesn't publish to GitHub or push Docker images.
+
+## GoReleaser Configuration
+
+The `.goreleaser.yaml` file configures the following release artifacts:
+
+### Binaries
+
+- **Platforms**: FreeBSD, Linux, macOS, Windows
+- **Architectures**: amd64, arm64 (FreeBSD arm64 excluded)
+- **Binary Name**: `opnDossier`
+- **Build Flags**: CGO disabled, stripped binaries with version info
+
+### Archives
+
+- **Format**: tar.gz (zip for Windows)
+- **Naming**: `opnDossier_OS_ARCH` format
+- **Includes**: LICENSE, README.md, CHANGELOG.md
+
+### Docker Images
+
+Two Docker image variants are built:
+
+1. **Standard Image**:
+
+   - `ghcr.io/evilbit-labs/opndossier:latest`
+   - `ghcr.io/evilbit-labs/opndossier:vX.Y.Z`
+   - `ghcr.io/evilbit-labs/opndossier:vX.Y`
+   - `ghcr.io/evilbit-labs/opndossier:vX`
+
+2. **POCL Variant**:
+
+   - Same tags with `-pocl` suffix
+   - Uses different build branch
+
+### Additional Artifacts
+
+- **Checksums**: `opnDossier_checksums.txt`
+- **SBOM**: Software Bill of Materials for archives
+- **Source Code**: Automatically included
+- **Universal Binaries**: For macOS (replaces individual arch binaries)
+
+## Dynamic Documentation Generation
+
+opnDossier uses Cobra's built-in capabilities to dynamically generate shell completions and man pages during the release process. This ensures documentation is always current with the actual command structure.
+
+### Shell Completions
+
+The CLI supports generating completions for multiple shells:
+
+```bash
+# Generate bash completion
+opndossier completion bash > ~/.bash_completion
+
+# Generate zsh completion
+opndossier completion zsh > "${fpath[1]}/_opndossier"
+
+# Generate fish completion
+opndossier completion fish > ~/.config/fish/completions/opndossier.fish
+
+# Generate PowerShell completion
+opndossier completion powershell > opndossier.ps1
+```
+
+### Man Pages
+
+Generate comprehensive man pages for all commands:
+
+```bash
+# Generate man pages in current directory
+opndossier man ./
+
+# Generate man pages in system location
+sudo opndossier man /usr/local/share/man/man1/
+```
+
+### Release Integration
+
+During the release process, GoReleaser automatically:
+
+1. Builds a temporary binary with correct version information
+2. Generates shell completions for bash, zsh, fish, and PowerShell
+3. Generates man pages for all commands and subcommands
+4. Includes these files in native packages (.deb, .rpm, .apk, .pkg.tar.xz)
+5. Cleans up temporary files
+
+This ensures that:
+
+- Package installations include working completions and man pages
+- Documentation is always synchronized with the actual CLI interface
+- No manual maintenance of static documentation files is required
+
+## Version Information
+
+Version information is injected into the binary at build time:
+
+- **Main Version**: Set via ldflags in GoReleaser (`main.version`)
+- **Build Date**: Available in CLI via `opnDossier version`
+- **Git Commit**: Available in CLI via `opnDossier version`
+
+The version is displayed using:
+
+```bash
+opnDossier version
+```
+
+## Changelog Generation
+
+The project uses `git-cliff` with a custom `cliff.toml` configuration:
+
+### Commit Categories
+
+Commits are automatically categorized based on conventional commit prefixes:
+
+- **Features**: `feat:` commits
+- **Bug Fixes**: `fix:` commits
+- **Security**: `fix(security):` commits or security-related changes
+- **Documentation**: `doc:` commits
+- **Performance**: `perf:` commits
+- **Refactor**: `refactor:` commits
+- **Styling**: `style:` commits
+- **Testing**: `test:` commits
+- **Miscellaneous**: `chore:` and `ci:` commits
+- **Revert**: `revert:` commits
+
+### Commit Message Format
+
+Follow conventional commits:
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+Examples:
+
+- `feat(auth): add OAuth2 support`
+- `fix(parser): handle malformed XML gracefully`
+- `docs: update installation instructions`
+
+## Troubleshooting
+
+### Common Issues
+
+1. **GoReleaser Configuration Errors**:
+
+   ```bash
+   just check-goreleaser
+   ```
+
+2. **Missing git-cliff**:
+
+   ```bash
+   just install-git-cliff
+   ```
+
+3. **Build Failures**:
+
+   - Check Go version compatibility (requires Go 1.24+)
+   - Ensure all tests pass: `just test`
+   - Verify dependencies: `go mod tidy`
+
+4. **Docker Login Issues**:
+
+   - Verify GITHUB_TOKEN permissions
+   - Check container registry access
+   - Ensure you're logged in: `docker login ghcr.io`
+   - Test Docker access: `docker pull ghcr.io/evilbit-labs/opndossier:latest`
+
+### Release Validation
+
+After a release, verify:
+
+1. **GitHub Release Page**:
+
+   - Release notes are generated correctly
+   - All binary artifacts are attached
+   - Checksums file is present
+
+2. **Docker Images**:
+
+   ```bash
+   docker pull ghcr.io/evilbit-labs/opndossier:latest
+   docker run --rm ghcr.io/evilbit-labs/opndossier:latest version
+   ```
+
+3. **Binary Downloads**:
+
+   - Test download and execution of binaries for your platform
+   - Verify version information is correct
+
+## Release Schedule
+
+opnDossier follows these release practices:
+
+- **Patch Releases**: As needed for critical bug fixes
+- **Minor Releases**: When new features are ready and tested
+- **Major Releases**: For breaking changes or significant milestones
+- **Pre-releases**: Beta and RC versions for testing before major releases
+
+## Security Considerations
+
+- All releases are signed and checksummed
+- Docker images include security labels and provenance information
+- macOS binaries can be notarized when certificates are configured
+- Dependencies are automatically updated via Dependabot
+- CodeQL analysis runs on all releases
+
+## Post-Release Tasks
+
+After a successful release:
+
+1. **Update Documentation**: Ensure docs reflect new features
+2. **Close Milestones**: Close the GitHub milestone for the release
+3. **Announce Release**: Update relevant channels about the new version
+4. **Monitor Issues**: Watch for any issues reported with the new release
+
+## Rollback Procedure
+
+If a release has critical issues:
+
+1. **Create Hotfix**: Fix the issue in a new patch release
+2. **Update GitHub Release**: Mark problematic release as pre-release if needed
+3. **Docker Images**: Latest tag will point to the new fixed version
+4. **Communication**: Notify users about the issue and fix
+
+---
+
+For questions about the release process, please refer to the project's [CONTRIBUTING.md](CONTRIBUTING.md) or open an issue.

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command.
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+  $ source <(opndossier completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ opndossier completion bash > /etc/bash_completion.d/opndossier
+  # macOS:
+  $ opndossier completion bash > $(brew --prefix)/etc/bash_completion.d/opndossier
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ opndossier completion zsh > "${fpath[1]}/_opndossier"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+  $ opndossier completion fish | source
+
+  # To load completions for each session, execute once:
+  $ opndossier completion fish > ~/.config/fish/completions/opndossier.fish
+
+PowerShell:
+  PS> opndossier completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> opndossier completion powershell > opndossier.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletion(os.Stdout)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -29,7 +29,7 @@ Example:
 		}
 
 		// Ensure the output directory exists
-		if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		if err := os.MkdirAll(outputDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
 		}
 

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+// manCmd represents the man command.
+var manCmd = &cobra.Command{
+	Use:   "man [output-directory]",
+	Short: "Generate man pages",
+	Long: `Generate man pages for opnDossier and all of its commands.
+
+If no output directory is specified, man pages will be written to './man/'.
+
+Example:
+  opndossier man
+  opndossier man /usr/local/share/man/man1/
+`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outputDir := "./man/"
+		if len(args) > 0 {
+			outputDir = args[0]
+		}
+
+		// Ensure the output directory exists
+		if err := os.MkdirAll(outputDir, 0o750); err != nil {
+			return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
+		}
+
+		// Set up the header for the man pages
+		header := &doc.GenManHeader{
+			Title:   "OPNDOSSIER",
+			Section: "1",
+			Source:  "opnDossier " + cmd.Root().Version,
+		}
+
+		// Generate man pages for all commands
+		if err := doc.GenManTree(cmd.Root(), header, outputDir); err != nil {
+			return fmt.Errorf("failed to generate man pages: %w", err)
+		}
+
+		fmt.Printf("Man pages generated successfully in %s\n", outputDir)
+
+		// List the generated files
+		files, err := filepath.Glob(filepath.Join(outputDir, "*.1"))
+		if err == nil && len(files) > 0 {
+			fmt.Println("Generated files:")
+			for _, file := range files {
+				fmt.Printf("  %s\n", file)
+			}
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(manCmd)
+}

--- a/cmd/man.go
+++ b/cmd/man.go
@@ -29,6 +29,7 @@ Example:
 		}
 
 		// Ensure the output directory exists
+		//nolint:gosec // Man pages require 755 permissions for public access
 		if err := os.MkdirAll(outputDir, 0o755); err != nil {
 			return fmt.Errorf("failed to create output directory %s: %w", outputDir, err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,10 +43,10 @@ WORKFLOW EXAMPLES:
   opnDossier --verbose convert config.xml --format json
 
   # Configuration management workflow
-  OPNDOSSIER_LOG_LEVEL=debug opnDossier convert config.xml --theme dark
+  opnDossier --verbose convert config.xml --theme dark
 
   # Template customization workflow
-  opnDossier convert config.xml --template-dir ~/.opnDossier/templates --template detailed
+  opnDossier convert config.xml --custom-template /path/to/my-template.tmpl
 
   # Compliance workflow
   opnDossier convert config.xml --mode blue --plugins stig,sans --comprehensive`,
@@ -117,18 +117,6 @@ func init() {
 	setFlagAnnotation(rootCmd.PersistentFlags(), "verbose", []string{"output"})
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress all output except errors and critical messages")
 	setFlagAnnotation(rootCmd.PersistentFlags(), "quiet", []string{"output"})
-
-	// Logging configuration flags
-	rootCmd.PersistentFlags().
-		String("log_level", "info", "Set logging level (debug, info, warn, error) for detailed output control")
-	setFlagAnnotation(rootCmd.PersistentFlags(), "log_level", []string{"logging"})
-	rootCmd.PersistentFlags().String("log_format", "text", "Set log output format (text, json) for structured logging")
-	setFlagAnnotation(rootCmd.PersistentFlags(), "log_format", []string{"logging"})
-
-	// Display configuration flags
-	rootCmd.PersistentFlags().
-		String("theme", "", "Set display theme (light, dark, auto, none) for terminal output styling")
-	setFlagAnnotation(rootCmd.PersistentFlags(), "theme", []string{"display"})
 
 	// Flag groups for better organization
 	rootCmd.PersistentFlags().SortFlags = false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,16 +57,10 @@ WORKFLOW EXAMPLES:
 		}
 
 		// Initialize logger after config load with proper verbose/quiet handling
+		// GetLogLevel() and GetLogFormat() are deprecated but still functional
+		// They now handle the verbose/quiet logic internally
 		logLevel := Cfg.GetLogLevel()
 		logFormat := Cfg.GetLogFormat()
-
-		// Honor --verbose/--quiet overrides with proper precedence
-		// CLI flags > env vars > config file > defaults
-		if Cfg.IsQuiet() {
-			logLevel = "error"
-		} else if Cfg.IsVerbose() {
-			logLevel = "debug"
-		}
 
 		// Create new logger with centralized configuration
 		var loggerErr error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,9 +36,6 @@ WORKFLOW EXAMPLES:
   # Basic conversion workflow
   opnDossier convert config.xml -o documentation.md
 
-  # Audit workflow with compliance checks
-  opnDossier convert config.xml --mode blue --plugins stig,sans
-
   # Development workflow with verbose logging
   opnDossier --verbose convert config.xml --format json
 
@@ -48,8 +45,8 @@ WORKFLOW EXAMPLES:
   # Template customization workflow
   opnDossier convert config.xml --custom-template /path/to/my-template.tmpl
 
-  # Compliance workflow
-  opnDossier convert config.xml --mode blue --plugins stig,sans --comprehensive`,
+  # Validation workflow
+  opnDossier validate config.xml && opnDossier convert config.xml -o documentation.md`,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 		var err error
 		// Load configuration with flag binding for proper precedence

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -38,21 +38,6 @@ func TestRootCmdFlags(t *testing.T) {
 	quietFlag := flags.Lookup("quiet")
 	require.NotNil(t, quietFlag)
 	assert.Equal(t, "false", quietFlag.DefValue)
-
-	// Check log_level flag
-	logLevelFlag := flags.Lookup("log_level")
-	require.NotNil(t, logLevelFlag)
-	assert.Equal(t, "info", logLevelFlag.DefValue)
-
-	// Check log_format flag
-	logFormatFlag := flags.Lookup("log_format")
-	require.NotNil(t, logFormatFlag)
-	assert.Equal(t, "text", logFormatFlag.DefValue)
-
-	// Check theme flag
-	themeFlag := flags.Lookup("theme")
-	require.NotNil(t, themeFlag)
-	assert.Empty(t, themeFlag.DefValue)
 }
 
 func TestRootCmdHelp(t *testing.T) {
@@ -79,16 +64,11 @@ func TestGetFlagsByCategory(t *testing.T) {
 	// Test that categories exist
 	assert.Contains(t, categories, "configuration")
 	assert.Contains(t, categories, "output")
-	assert.Contains(t, categories, "logging")
-	assert.Contains(t, categories, "display")
 
 	// Test specific flags in categories
 	assert.Contains(t, categories["configuration"], "config")
 	assert.Contains(t, categories["output"], "verbose")
 	assert.Contains(t, categories["output"], "quiet")
-	assert.Contains(t, categories["logging"], "log_level")
-	assert.Contains(t, categories["logging"], "log_format")
-	assert.Contains(t, categories["display"], "theme")
 }
 
 func TestRootCmdSubcommands(t *testing.T) {

--- a/cmd/shared_flags.go
+++ b/cmd/shared_flags.go
@@ -1,0 +1,134 @@
+// Package cmd provides the command-line interface for opnDossier.
+package cmd
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/audit"
+	"github.com/EvilBit-Labs/opnDossier/internal/log"
+	"github.com/EvilBit-Labs/opnDossier/internal/markdown"
+	"github.com/EvilBit-Labs/opnDossier/internal/model"
+	"github.com/spf13/cobra"
+)
+
+// Shared flag variables for convert and display commands.
+var (
+	// Template and styling flags.
+	sharedSections        []string //nolint:gochecknoglobals // Sections to include
+	sharedTheme           string   //nolint:gochecknoglobals // Theme for rendering
+	sharedWrapWidth       int      //nolint:gochecknoglobals // Text wrap width
+	sharedCustomTemplate  string   //nolint:gochecknoglobals // Custom template file path
+	sharedIncludeTunables bool     //nolint:gochecknoglobals // Include system tunables in output
+
+	// TODO: Audit mode functionality is not yet complete - disabled for now
+	// sharedAuditMode       string   //nolint:gochecknoglobals // Audit mode (standard, blue, red)
+	// sharedBlackhatMode    bool     //nolint:gochecknoglobals // Enable blackhat mode for red team reports.
+	sharedComprehensive bool //nolint:gochecknoglobals // Generate comprehensive report
+	// sharedSelectedPlugins []string //nolint:gochecknoglobals // Selected compliance plugins.
+)
+
+// addSharedTemplateFlags adds template flags that are common to both convert and display commands.
+func addSharedTemplateFlags(cmd *cobra.Command) {
+	// Template flags
+	cmd.Flags().
+		StringVar(&sharedCustomTemplate, "custom-template", "", "Path to custom GoTemplate file (overrides built-in templates)")
+	setFlagAnnotation(cmd.Flags(), "custom-template", []string{"template"})
+
+	cmd.Flags().
+		BoolVar(&sharedIncludeTunables, "include-tunables", false, "Include system tunables in the output report")
+	setFlagAnnotation(cmd.Flags(), "include-tunables", []string{"template"})
+
+	cmd.Flags().
+		StringSliceVar(&sharedSections, "section", []string{}, "Specific sections to include in output (comma-separated, e.g., system,network,firewall)")
+	setFlagAnnotation(cmd.Flags(), "section", []string{"template"})
+
+	cmd.Flags().
+		IntVar(&sharedWrapWidth, "wrap", 0, "Text wrap width in characters (0 = no wrapping, recommended: 80-120)")
+	setFlagAnnotation(cmd.Flags(), "wrap", []string{"template"})
+}
+
+// addDisplayFlags adds display-specific flags (theme for glamour rendering).
+func addDisplayFlags(cmd *cobra.Command) {
+	cmd.Flags().
+		StringVar(&sharedTheme, "theme", "", "Theme for rendering output (light, dark, auto, none)")
+	setFlagAnnotation(cmd.Flags(), "theme", []string{"template"})
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// addSharedAuditFlags adds the shared audit mode flags to a command.
+// These flags are used by the convert command for audit report generation.
+func addSharedAuditFlags(cmd *cobra.Command) {
+	// TODO: Audit mode flags are disabled until audit functionality is complete
+	// Audit mode flags are commented out until audit functionality is complete
+
+	cmd.Flags().
+		BoolVar(&sharedComprehensive, "comprehensive", false, "Generate comprehensive detailed reports with full configuration analysis")
+	setFlagAnnotation(cmd.Flags(), "comprehensive", []string{"audit"})
+}
+
+// getSharedTemplateDir returns the template directory path from the custom template flag.
+// If custom-template is set, it extracts the directory path from the file path.
+func getSharedTemplateDir() string {
+	if sharedCustomTemplate == "" {
+		return ""
+	}
+	// Extract directory from custom template file path
+	// This maintains backward compatibility with the old template-dir behavior
+	// but simplifies the user experience by requiring only one flag
+	return filepath.Dir(sharedCustomTemplate)
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// handleAuditMode generates an audit report using the audit mode controller and markdown generator.
+func handleAuditMode(
+	_ context.Context,
+	_ *model.OpnSenseDocument,
+	_ markdown.Options,
+	_ *log.Logger,
+	_ *audit.PluginRegistry,
+) (string, error) {
+	// TODO: Audit mode is disabled until audit functionality is complete
+	return "", errors.New("audit mode functionality is not yet implemented")
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// convertAuditModeToReportMode converts markdown audit mode to audit report mode.
+func convertAuditModeToReportMode(_ markdown.AuditMode) (audit.ReportMode, error) {
+	// TODO: Audit mode is disabled until audit functionality is complete
+	return audit.ModeStandard, errors.New("audit mode functionality is not yet implemented")
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// createModeConfig creates an audit mode configuration from options.
+func createModeConfig(_ audit.ReportMode, _ markdown.Options) *audit.ModeConfig {
+	// TODO: Audit mode is disabled until audit functionality is complete
+	return &audit.ModeConfig{}
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// generateBaseAuditReport generates the base audit report using template rendering.
+func generateBaseAuditReport(
+	_ context.Context,
+	_ *model.OpnSenseDocument,
+	_ markdown.Options,
+	_ *log.Logger,
+) (string, error) {
+	// TODO: Audit mode is disabled until audit functionality is complete
+	return "", errors.New("audit mode functionality is not yet implemented")
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// createAuditMarkdownOptions creates markdown options specifically for audit mode.
+func createAuditMarkdownOptions(_ markdown.Options) markdown.Options {
+	// TODO: Audit mode is disabled until audit functionality is complete
+	return markdown.Options{}
+}
+
+// TODO: Audit mode functionality is not yet complete - disabled for now
+// appendAuditFindings appends audit findings summary to the report.
+func appendAuditFindings(result string, _ *audit.Report) string {
+	// TODO: Audit mode is disabled until audit functionality is complete
+	return result
+}

--- a/docs/examples/advanced-configuration.md
+++ b/docs/examples/advanced-configuration.md
@@ -1,5 +1,9 @@
 # Advanced Configuration Examples
 
+> **⚠️ Note: Some examples in this guide reference audit functionality that is not yet implemented in opnDossier v1.0.**
+>
+> Examples using `--mode`, `--blackhat-mode`, and `--plugins` flags are for future releases. These flags are currently disabled and not available in the current version.
+
 This guide covers advanced configuration options and customization techniques for opnDossier.
 
 ## Custom Templates

--- a/docs/examples/audit-compliance.md
+++ b/docs/examples/audit-compliance.md
@@ -1,6 +1,12 @@
 # Audit and Compliance Examples
 
-This guide covers security auditing and compliance checking workflows using opnDossier.
+> **⚠️ Note: Audit and compliance functionality is not yet implemented in opnDossier v1.0.**
+>
+> This documentation describes planned features for future releases. The audit mode flags (`--mode`, `--blackhat-mode`, `--plugins`) are currently disabled and not available in the current version.
+>
+> For current functionality, see the [Basic Usage](../user-guide/usage.md) and [Advanced Configuration](advanced-configuration.md) guides.
+
+This guide covers security auditing and compliance checking workflows using opnDossier (planned for future releases).
 
 ## Security Audit Reports
 

--- a/docs/examples/automation-scripting.md
+++ b/docs/examples/automation-scripting.md
@@ -1,5 +1,9 @@
 # Automation and Scripting Examples
 
+> **⚠️ Note: Some examples in this guide reference audit functionality that is not yet implemented in opnDossier v1.0.**
+>
+> Examples using `--mode`, `--blackhat-mode`, and `--plugins` flags are for future releases. These flags are currently disabled and not available in the current version.
+
 This guide covers automation workflows and scripting examples for integrating opnDossier into CI/CD pipelines and automated processes.
 
 ## CI/CD Integration

--- a/docs/examples/troubleshooting.md
+++ b/docs/examples/troubleshooting.md
@@ -1,5 +1,9 @@
 # Troubleshooting and Debugging Examples
 
+> **⚠️ Note: Some examples in this guide reference audit functionality that is not yet implemented in opnDossier v1.0.**
+>
+> Examples using `--mode`, `--blackhat-mode`, and `--plugins` flags are for future releases. These flags are currently disabled and not available in the current version.
+
 This guide covers common issues, error handling, and debugging techniques for opnDossier.
 
 ## Common Error Scenarios

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/charmbracelet/x/exp/color v0.0.0-20250725211024-d60e1b0112b2 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250725211024-d60e1b0112b2 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -77,6 +78,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.10.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -150,6 +151,7 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.10.0 h1:FM8Cv6j2KqIhM2ZK7HZjm4mpj9NBktLgowT1aN9q5Cc=
 github.com/sagikazarmark/locafero v0.10.0/go.mod h1:Ieo3EUsjifvQu4NZwV5sPd4dwvu0OCgEQV7vjc9yDjw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,13 +248,30 @@ func combineValidationErrors(validationErrors []ValidationError) error {
 }
 
 // GetLogLevel returns the configured log level.
+// Deprecated: This method is deprecated and will be removed in a future version.
+// Use IsVerbose() and IsQuiet() methods instead for logging control.
+// The log level is now determined by the Verbose and Quiet flags:
+// - Quiet mode: "error"
+// - Verbose mode: "debug"
+// - Default: "info".
 func (c *Config) GetLogLevel() string {
-	return "" // No longer available
+	// TODO: Remove this method in next major version
+	// For now, return appropriate level based on current config
+	if c.IsQuiet() {
+		return "error"
+	}
+	if c.IsVerbose() {
+		return "debug"
+	}
+	return "info"
 }
 
 // GetLogFormat returns the configured log format.
+// Deprecated: This method is deprecated and will be removed in a future version.
+// Log format is now hardcoded to "text" format for consistency.
 func (c *Config) GetLogFormat() string {
-	return "" // No longer available
+	// TODO: Remove this method in next major version
+	return "text"
 }
 
 // IsVerbose returns true if verbose logging is enabled.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,8 +18,6 @@ type Config struct {
 	OutputFile string   `mapstructure:"output_file"`
 	Verbose    bool     `mapstructure:"verbose"`
 	Quiet      bool     `mapstructure:"quiet"`
-	LogLevel   string   `mapstructure:"log_level"`
-	LogFormat  string   `mapstructure:"log_format"`
 	Theme      string   `mapstructure:"theme"`
 	Format     string   `mapstructure:"format"`
 	Template   string   `mapstructure:"template"`
@@ -64,8 +62,6 @@ func LoadConfigWithViper(cfgFile string, v *viper.Viper) (*Config, error) {
 	v.SetDefault("output_file", "")
 	v.SetDefault("verbose", false)
 	v.SetDefault("quiet", false)
-	v.SetDefault("log_level", "info")
-	v.SetDefault("log_format", "text")
 	v.SetDefault("theme", "")
 	v.SetDefault("format", "markdown")
 	v.SetDefault("template", "")
@@ -131,8 +127,6 @@ func (c *Config) Validate() error {
 	validateFlags(c, &validationErrors)
 	validateInputFile(c, &validationErrors)
 	validateOutputFile(c, &validationErrors)
-	validateLogLevel(c, &validationErrors)
-	validateLogFormat(c, &validationErrors)
 	validateTheme(c, &validationErrors)
 	validateFormat(c, &validationErrors)
 	validateWrapWidth(c, &validationErrors)
@@ -185,40 +179,6 @@ func validateOutputFile(c *Config, validationErrors *[]ValidationError) {
 				})
 			}
 		}
-	}
-}
-
-func validateLogLevel(c *Config, validationErrors *[]ValidationError) {
-	// Validate log level
-	validLogLevels := map[string]bool{
-		"debug":   true,
-		"info":    true,
-		"warn":    true,
-		"warning": true,
-		"error":   true,
-	}
-	if !validLogLevels[c.LogLevel] {
-		*validationErrors = append(*validationErrors, ValidationError{
-			Field: "log_level",
-			Message: fmt.Sprintf(
-				"invalid log level '%s', must be one of: debug, info, warn, warning, error",
-				c.LogLevel,
-			),
-		})
-	}
-}
-
-func validateLogFormat(c *Config, validationErrors *[]ValidationError) {
-	// Validate log format
-	validLogFormats := map[string]bool{
-		"text": true,
-		"json": true,
-	}
-	if !validLogFormats[c.LogFormat] {
-		*validationErrors = append(*validationErrors, ValidationError{
-			Field:   "log_format",
-			Message: fmt.Sprintf("invalid log format '%s', must be one of: text, json", c.LogFormat),
-		})
 	}
 }
 
@@ -289,12 +249,12 @@ func combineValidationErrors(validationErrors []ValidationError) error {
 
 // GetLogLevel returns the configured log level.
 func (c *Config) GetLogLevel() string {
-	return c.LogLevel
+	return "" // No longer available
 }
 
 // GetLogFormat returns the configured log format.
 func (c *Config) GetLogFormat() string {
-	return c.LogFormat
+	return "" // No longer available
 }
 
 // IsVerbose returns true if verbose logging is enabled.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,8 +42,6 @@ log_format: json
 	assert.Equal(t, filepath.Join(tmpDir, "output.md"), cfg.OutputFile)
 	assert.True(t, cfg.Verbose)
 	assert.False(t, cfg.Quiet)
-	assert.Equal(t, "debug", cfg.LogLevel)
-	assert.Equal(t, "json", cfg.LogFormat)
 }
 
 func TestLoadConfigFromEnv(t *testing.T) {
@@ -118,45 +116,21 @@ func TestConfig_Validate(t *testing.T) {
 				OutputFile: "",
 				Verbose:    false,
 				Quiet:      false,
-				LogLevel:   "info",
-				LogFormat:  "text",
 			},
 			wantErr: false,
 		},
 		{
 			name: "mutually_exclusive_verbose_quiet",
 			config: Config{
-				Verbose:   true,
-				Quiet:     true,
-				LogLevel:  "info",
-				LogFormat: "text",
+				Verbose: true,
+				Quiet:   true,
 			},
 			wantErr: false, // Validation now handled by Cobra flag validation
-		},
-		{
-			name: "invalid_log_level",
-			config: Config{
-				LogLevel:  "invalid",
-				LogFormat: "text",
-			},
-			wantErr: true,
-			errMsg:  "invalid log level 'invalid'",
-		},
-		{
-			name: "invalid_log_format",
-			config: Config{
-				LogLevel:  "info",
-				LogFormat: "invalid",
-			},
-			wantErr: true,
-			errMsg:  "invalid log format 'invalid'",
 		},
 		{
 			name: "nonexistent_input_file",
 			config: Config{
 				InputFile: "/nonexistent/file.xml",
-				LogLevel:  "info",
-				LogFormat: "text",
 			},
 			wantErr: true,
 			errMsg:  "input file does not exist",
@@ -165,8 +139,6 @@ func TestConfig_Validate(t *testing.T) {
 			name: "nonexistent_output_directory",
 			config: Config{
 				OutputFile: "/nonexistent/dir/output.md",
-				LogLevel:   "info",
-				LogFormat:  "text",
 			},
 			wantErr: true,
 			errMsg:  "output directory does not exist",
@@ -189,16 +161,12 @@ func TestConfig_Validate(t *testing.T) {
 
 func TestConfig_HelperMethods(t *testing.T) {
 	cfg := &Config{
-		Verbose:   true,
-		Quiet:     false,
-		LogLevel:  "debug",
-		LogFormat: "json",
+		Verbose: true,
+		Quiet:   false,
 	}
 
 	assert.True(t, cfg.IsVerbose())
 	assert.False(t, cfg.IsQuiet())
-	assert.Equal(t, "debug", cfg.GetLogLevel())
-	assert.Equal(t, "json", cfg.GetLogFormat())
 }
 
 func TestLoadConfigFromEnvWithNewFields(t *testing.T) {
@@ -207,15 +175,11 @@ func TestLoadConfigFromEnvWithNewFields(t *testing.T) {
 
 	// Set environment variables for new fields
 	t.Setenv("OPNDOSSIER_QUIET", "true")
-	t.Setenv("OPNDOSSIER_LOG_LEVEL", "warn")
-	t.Setenv("OPNDOSSIER_LOG_FORMAT", "json")
 
 	cfg, err := LoadConfigWithViper("", viper.New())
 	require.NoError(t, err)
 	assert.NotNil(t, cfg)
 	assert.True(t, cfg.Quiet)
-	assert.Equal(t, "warn", cfg.LogLevel)
-	assert.Equal(t, "json", cfg.LogFormat)
 }
 
 func TestLoadConfigFromEnvWithAllFields(t *testing.T) {
@@ -234,8 +198,6 @@ func TestLoadConfigFromEnvWithAllFields(t *testing.T) {
 	t.Setenv("OPNDOSSIER_OUTPUT_FILE", outputFile)
 	t.Setenv("OPNDOSSIER_VERBOSE", "true")
 	t.Setenv("OPNDOSSIER_QUIET", "false")
-	t.Setenv("OPNDOSSIER_LOG_LEVEL", "debug")
-	t.Setenv("OPNDOSSIER_LOG_FORMAT", "json")
 	t.Setenv("OPNDOSSIER_THEME", "dark")
 	t.Setenv("OPNDOSSIER_FORMAT", "yaml")
 	t.Setenv("OPNDOSSIER_TEMPLATE", "comprehensive")
@@ -251,8 +213,6 @@ func TestLoadConfigFromEnvWithAllFields(t *testing.T) {
 	assert.Equal(t, outputFile, cfg.OutputFile)
 	assert.True(t, cfg.Verbose)
 	assert.False(t, cfg.Quiet)
-	assert.Equal(t, "debug", cfg.LogLevel)
-	assert.Equal(t, "json", cfg.LogFormat)
 	assert.Equal(t, "dark", cfg.Theme)
 	assert.Equal(t, "yaml", cfg.Format)
 	assert.Equal(t, "comprehensive", cfg.Template)

--- a/internal/markdown/formatters.go
+++ b/internal/markdown/formatters.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/EvilBit-Labs/opnDossier/internal/constants"
 	"github.com/yuin/goldmark"
@@ -583,4 +584,24 @@ func FormatBooleanWithUnset(value any) string {
 		return checkboxChecked
 	}
 	return checkboxUnchecked
+}
+
+// FormatUnixTimestamp converts a Unix timestamp string to an ISO 8601 formatted date.
+func FormatUnixTimestamp(timestamp string) string {
+	if timestamp == "" {
+		return "-"
+	}
+
+	// Try to parse as float64 (handles both integer and decimal timestamps)
+	ts, err := strconv.ParseFloat(timestamp, 64)
+	if err != nil {
+		return timestamp // Return original if parsing fails
+	}
+
+	// Convert to time.Time
+	const nanosecondsPerSecond = 1e9
+	t := time.Unix(int64(ts), int64((ts-float64(int64(ts)))*nanosecondsPerSecond))
+
+	// Format as ISO 8601
+	return t.Format("2006-01-02T15:04:05Z07:00")
 }

--- a/internal/markdown/formatters.go
+++ b/internal/markdown/formatters.go
@@ -599,8 +599,7 @@ func FormatUnixTimestamp(timestamp string) string {
 	}
 
 	// Convert to time.Time
-	const nanosecondsPerSecond = 1e9
-	t := time.Unix(int64(ts), int64((ts-float64(int64(ts)))*nanosecondsPerSecond))
+	t := time.Unix(int64(ts), int64((ts-float64(int64(ts)))*float64(time.Second)))
 
 	// Format as ISO 8601
 	return t.Format("2006-01-02T15:04:05Z07:00")

--- a/internal/markdown/generator.go
+++ b/internal/markdown/generator.go
@@ -213,6 +213,7 @@ func createTemplateFuncMap() template.FuncMap {
 	funcMap["isTruthy"] = IsTruthy
 	funcMap["formatBoolean"] = FormatBoolean
 	funcMap["formatBooleanWithUnset"] = FormatBooleanWithUnset
+	funcMap["formatUnixTimestamp"] = FormatUnixTimestamp
 
 	return funcMap
 }

--- a/internal/templates/opnsense_report_comprehensive.md.tmpl
+++ b/internal/templates/opnsense_report_comprehensive.md.tmpl
@@ -21,7 +21,9 @@
 - [System Groups](#system-groups)
 - [System Tunables](#system-tunables)
 - [Gateways](#gateways)
+{{- if or (and .OPNsense.Wireguard .OPNsense.Wireguard.General) (and .OPNsense.Wireguard .OPNsense.Wireguard.Server .OPNsense.Wireguard.Server.Servers .OPNsense.Wireguard.Server.Servers.Server) (and .OPNsense.Wireguard .OPNsense.Wireguard.Client .OPNsense.Wireguard.Client.Clients .OPNsense.Wireguard.Client.Clients.Client) }}
 - [WireGuard VPN](#wireguard-vpn)
+{{- end }}
 - [Revision History](#revision-history)
 
 ---
@@ -159,11 +161,38 @@
 | {{ $name }} | {{ formatBoolean $dhcp.Enable }} | `{{ $dhcp.Gateway }}` | {{ $dhcp.Range.From }} | {{ $dhcp.Range.To }} | `{{ $dhcp.Dnsserver }}` | `{{ $dhcp.Winsserver }}` | `{{ $dhcp.Ntpserver }}` | `{{ $dhcp.DdnsDomainAlgorithm }}` |
 {{- end }}
 
+{{- $hasOptions := false }}
+{{- range $name, $dhcp := .Dhcpd.Items }}
+{{- if $dhcp.NumberOptions }}
+{{- range $dhcp.NumberOptions }}
+{{- if or .Number .Type .Value }}
+{{- $hasOptions = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $hasOptions }}
 ### DHCP Options
 {{- range $name, $dhcp := .Dhcpd.Items }}
-#### {{ $name | title }} DHCP Options
 {{- if $dhcp.NumberOptions }}
-- **Number Options**: {{ len $dhcp.NumberOptions }} configured
+{{- $hasValidOptions := false }}
+{{- range $dhcp.NumberOptions }}
+{{- if or .Number .Type .Value }}
+{{- $hasValidOptions = true }}
+{{- end }}
+{{- end }}
+{{- if $hasValidOptions }}
+#### {{ $name | title }} DHCP Options
+| Option Number | Type | Value |
+|---------------|------|-------|
+{{- range $dhcp.NumberOptions }}
+{{- if or .Number .Type .Value }}
+| {{ .Number }} | {{ if .Type }}{{ .Type }}{{ else }}-{{ end }} | `{{ .Value }}` |
+{{- end }}
+{{- end }}
+
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -235,23 +264,19 @@
 
 ---
 
+{{- if or (and .OPNsense.Wireguard .OPNsense.Wireguard.General) (and .OPNsense.Wireguard .OPNsense.Wireguard.Server .OPNsense.Wireguard.Server.Servers .OPNsense.Wireguard.Server.Servers.Server) (and .OPNsense.Wireguard .OPNsense.Wireguard.Client .OPNsense.Wireguard.Client.Clients .OPNsense.Wireguard.Client.Clients.Client) }}
 ## WireGuard VPN
 
-### Debug Information
-| Property | Value |
-|----------|-------|
-| **OPNsense Field Exists** | {{ if .OPNsense }}Yes{{ else }}No{{ end }} |
-| **OPNsense Type** | {{ printf "%T" .OPNsense }} |
-| **WireGuard Field Exists** | {{ if .OPNsense.Wireguard }}Yes{{ else }}No{{ end }} |
-
+{{- if and .OPNsense.Wireguard .OPNsense.Wireguard.General }}
 ### General Configuration
 | Property | Value |
 |----------|-------|
-| **Enabled** | {{ if .OPNsense.Wireguard }}{{ if .OPNsense.Wireguard.General }}{{ formatBoolean .OPNsense.Wireguard.General.Enabled }}{{ else }}Not configured{{ end }}{{ else }}Not configured{{ end }} |
-| **Version** | {{ if .OPNsense.Wireguard }}{{ if .OPNsense.Wireguard.General }}{{ .OPNsense.Wireguard.General.Version }}{{ else }}Not configured{{ end }}{{ else }}Not configured{{ end }} |
+| **Enabled** | {{ formatBoolean .OPNsense.Wireguard.General.Enabled }} |
+| **Version** | {{ .OPNsense.Wireguard.General.Version }} |
 
-### Servers
+{{- end }}
 {{- if and .OPNsense.Wireguard .OPNsense.Wireguard.Server .OPNsense.Wireguard.Server.Servers .OPNsense.Wireguard.Server.Servers.Server }}
+### Servers
 {{- range .OPNsense.Wireguard.Server.Servers.Server }}
 #### Server: {{ .Name }}
 | Property | Value |
@@ -271,12 +296,9 @@
 **Private Key**: `{{ .Privkey }}`
 
 {{- end }}
-{{- else }}
-No WireGuard servers configured.
 {{- end }}
-
-### Clients
 {{- if and .OPNsense.Wireguard .OPNsense.Wireguard.Client .OPNsense.Wireguard.Client.Clients .OPNsense.Wireguard.Client.Clients.Client }}
+### Clients
 {{- range .OPNsense.Wireguard.Client.Clients.Client }}
 #### Client: {{ .Name }}
 | Property | Value |
@@ -292,20 +314,21 @@ No WireGuard servers configured.
 **PSK**: `{{ .PSK }}`
 
 {{- end }}
-{{- else }}
-No WireGuard clients configured.
 {{- end }}
 
 ---
+{{- end }}
 
+{{- if and .Revision (or .Revision.Username .Revision.Time .Revision.Description) }}
 ## Revision History
 
 | Username | Time | Description |
 |----------|------|-------------|
-{{- if .Revision }}
-| `{{ .Revision.Username }}` | {{ .Revision.Time }} | `{{ .Revision.Description }}` |
+| `{{ .Revision.Username }}` | {{ formatUnixTimestamp .Revision.Time }} | `{{ .Revision.Description }}` |
 {{- else }}
-| No revision history available | - | - |
+## Revision History
+
+*No revision history available for this configuration.*
 {{- end }}
 
 ---
@@ -320,8 +343,10 @@ No WireGuard clients configured.
 - **Total Sysctl Tunables**: {{ len .Sysctl }}
 - **Total DHCP Scopes**: {{ len .Dhcpd.Items }}
 - **Total Gateways**: {{ len .Gateways.Gateway }}
+{{- if or (and .OPNsense.Wireguard .OPNsense.Wireguard.General) (and .OPNsense.Wireguard .OPNsense.Wireguard.Server .OPNsense.Wireguard.Server.Servers .OPNsense.Wireguard.Server.Servers.Server) (and .OPNsense.Wireguard .OPNsense.Wireguard.Client .OPNsense.Wireguard.Client.Clients .OPNsense.Wireguard.Client.Clients.Client) }}
 - **WireGuard Servers**: {{ if and .OPNsense.Wireguard .OPNsense.Wireguard.Server .OPNsense.Wireguard.Server.Servers .OPNsense.Wireguard.Server.Servers.Server }}{{ len .OPNsense.Wireguard.Server.Servers.Server }}{{ else }}0{{ end }}
 - **WireGuard Clients**: {{ if and .OPNsense.Wireguard .OPNsense.Wireguard.Client .OPNsense.Wireguard.Client.Clients .OPNsense.Wireguard.Client.Clients.Client }}{{ len .OPNsense.Wireguard.Client.Clients.Client }}{{ else }}0{{ end }}
+{{- end }}
 
 ### Security Assessment
 - **Web GUI Protocol**: {{ if eq .System.WebGUI.Protocol "https" }}Secure{{ else }}Insecure{{ end }}

--- a/internal/templates/opnsense_report_comprehensive.md.tmpl
+++ b/internal/templates/opnsense_report_comprehensive.md.tmpl
@@ -324,7 +324,7 @@
 
 | Username | Time | Description |
 |----------|------|-------------|
-| `{{ .Revision.Username }}` | {{ formatUnixTimestamp .Revision.Time }} | `{{ .Revision.Description }}` |
+| `{{ if .Revision.Username }}{{ .Revision.Username }}{{ else }}-{{ end }}` | {{ if .Revision.Time }}{{ formatUnixTimestamp .Revision.Time }}{{ else }}-{{ end }} | `{{ if .Revision.Description }}{{ .Revision.Description }}{{ else }}-{{ end }}` |
 {{- else }}
 ## Revision History
 


### PR DESCRIPTION
This pull request introduces significant updates to the `.goreleaser.yaml` configuration file to enhance the build, packaging, and release processes for the `opndossier` project. Key changes include the addition of shell completions, man page generation, improved release notes, and support for multiple package formats. Additionally, the changelog generation has been disabled, and Docker image configurations have been streamlined.

### Enhancements to build and packaging:
- Added hooks to generate shell completions, man pages, and a temporary binary during the build process, along with cleanup steps for the temporary binary (`.goreleaser.yaml`, [.goreleaser.yamlR10-R26](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R10-R26)).
- Introduced support for multiple package formats (`deb`, `rpm`, `apk`, `archlinux`) using `nfpm`, with metadata like dependencies, recommendations, and file structure for documentation and completions (`.goreleaser.yaml`, [.goreleaser.yamlL93-R234](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L93-R234)).
- Added the `-trimpath` flag to builds and included `mod_timestamp` for reproducibility (`.goreleaser.yaml`, [.goreleaser.yamlL23-R44](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L23-R44)).

### Improvements to release process:
- Enhanced release notes with a header, footer, installation instructions, and checksum verification steps. Also added Docker pull instructions (`.goreleaser.yaml`, [.goreleaser.yamlR74-R123](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R74-R123)).
- Disabled automatic changelog generation and removed changelog grouping and filters (`.goreleaser.yaml`, [.goreleaser.yamlL46-R64](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L46-R64)).

### Streamlining Docker configurations:
- Removed redundant Docker image templates and build configurations for the `pocl` tag, simplifying the `dockers` section (`.goreleaser.yaml`, [.goreleaser.yamlL93-R234](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L93-R234)).