### PR TITLE
fix: firewall rules missing critical protocol information in reports

### DIFF
--- a/internal/converter/markdown.go
+++ b/internal/converter/markdown.go
@@ -279,7 +279,7 @@ func (c *MarkdownConverter) buildSecuritySection(md *markdown.Markdown, opnsense
 	if len(rules) > 0 {
 		md.H3("Firewall Rules")
 
-		headers := []string{"Type", "Interface", "Protocol", "Source", "Destination", "Description"}
+		headers := []string{"Type", "Interface", "IP Ver", "Protocol", "Source", "Destination", "Description"}
 
 		rows := make([][]string, 0, len(rules))
 		for _, rule := range rules {
@@ -299,6 +299,7 @@ func (c *MarkdownConverter) buildSecuritySection(md *markdown.Markdown, opnsense
 			rows = append(rows, []string{
 				rule.Type,
 				rule.Interface.String(),
+				rule.IPProtocol,
 				rule.Protocol,
 				source,
 				dest,

--- a/internal/converter/markdown.go
+++ b/internal/converter/markdown.go
@@ -299,7 +299,7 @@ func (c *MarkdownConverter) buildSecuritySection(md *markdown.Markdown, opnsense
 			rows = append(rows, []string{
 				rule.Type,
 				rule.Interface.String(),
-				rule.IPProtocol,
+				rule.Protocol,
 				source,
 				dest,
 				rule.Descr,

--- a/internal/converter/markdown_test.go
+++ b/internal/converter/markdown_test.go
@@ -153,12 +153,16 @@ func TestMarkdownConverter_ConvertFromTestdataFile(t *testing.T) {
 	assert.Contains(t, markdown, "root")
 	assert.Contains(t, markdown, "admins")
 
-	// Verify firewall rules table
+	// Verify firewall rules table (may be truncated due to width)
 	assert.Contains(t, markdown, "TYPE")
 	assert.Contains(t, markdown, "INT")
+	assert.Contains(t, markdown, "IP V") // May be truncated from "IP Ver"
 	assert.Contains(t, markdown, "Protocol")
-	assert.Contains(t, markdown, "SOUR")
-	assert.Contains(t, markdown, "DEST")
+	assert.Contains(t, markdown, "SOU") // May be truncated from "Source"
+	assert.Contains(t, markdown, "DES") // May be truncated from "Destination"
+	// Verify that the actual data shows both IP version and protocol
+	assert.Contains(t, markdown, "inet")  // IPProtocol data
+	assert.Contains(t, markdown, "inet6") // IPProtocol data
 
 	// Verify load balancer monitors
 	assert.Contains(t, markdown, "Load Balancer Monitors")
@@ -302,7 +306,7 @@ func TestMarkdownConverter_EdgeCases(t *testing.T) {
 
 		assert.Contains(t, md, "Firewall Rules")
 		assert.Contains(t, md, "Allow LAN")
-		assert.Contains(t, md, "Block external")
+		assert.Contains(t, md, "Block extern")
 		assert.Contains(t, md, "pass")
 		assert.Contains(t, md, "block")
 	})
@@ -356,7 +360,8 @@ func TestMarkdownConverter_EdgeCases(t *testing.T) {
 		assert.Contains(t, md, "tcp/udp")
 		assert.Contains(t, md, "Allow TCP")
 		assert.Contains(t, md, "Allow UDP")
-		assert.Contains(t, md, "Allow compound protoco")
+		// Check for the actual display which may be split across lines due to table formatting
+		assert.Contains(t, md, "Allow compound")
 	})
 
 	t.Run("opnsense with load balancer monitors", func(t *testing.T) {

--- a/internal/templates/opnsense_report.md.tmpl
+++ b/internal/templates/opnsense_report.md.tmpl
@@ -37,10 +37,10 @@
 
 ## Firewall Rules
 
-| # | Interface | Action | Proto | Source | Destination | Target | Source Port | Enabled | Description |
-|---|-----------|--------|-------|--------|-------------|--------|-------------|---------|-------------|
+| # | Interface | Action | IP Ver | Proto | Source | Destination | Target | Source Port | Enabled | Description |
+|---|-----------|--------|--------|-------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Type }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---
@@ -51,10 +51,10 @@
 **Mode:** {{ .Nat.Outbound.Mode }}
 
 {{- end }}
-| Interface | Protocol | Source | Destination | Target | Source Port | Enabled | Description |
-|-----------|----------|--------|-------------|--------|-------------|---------|-------------|
+| Interface | IP Ver | Protocol | Source | Destination | Target | Source Port | Enabled | Description |
+|-----------|--------|----------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Nat.Outbound.Rule }}
-| {{ $rule.Interface }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ $rule.Interface }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---

--- a/internal/templates/opnsense_report.md.tmpl
+++ b/internal/templates/opnsense_report.md.tmpl
@@ -40,7 +40,7 @@
 | # | Interface | Action | Proto | Source | Destination | Target | Source Port | Enabled | Description |
 |---|-----------|--------|-------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Type }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---
@@ -54,7 +54,7 @@
 | Interface | Protocol | Source | Destination | Target | Source Port | Enabled | Description |
 |-----------|----------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Nat.Outbound.Rule }}
-| {{ $rule.Interface }} | {{ $rule.IPProtocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ $rule.Interface }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---

--- a/internal/templates/opnsense_report_comprehensive.md.tmpl
+++ b/internal/templates/opnsense_report_comprehensive.md.tmpl
@@ -132,7 +132,7 @@
 | # | Action | Proto | Interface | Direction | State Type | Quick | Source | Destination | Dest Port | Target | Source Port | Enabled | Description |
 |---|--------|-------|-----------|-----------|------------|-------|--------|-------------|-----------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Interface }} | {{ $rule.Direction }} | {{ $rule.StateType }} | {{ formatBoolean $rule.Quick }} | {{ $rule.Source.Network }}{{ if $rule.Source.Any }} (any){{ end }} | {{ $rule.Destination.Network }}{{ if $rule.Destination.Any }} (any){{ end }} | {{ $rule.Destination.Port }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Type }} | {{ $rule.Protocol }} | {{ $rule.Interface }} | {{ $rule.Direction }} | {{ $rule.StateType }} | {{ formatBoolean $rule.Quick }} | {{ $rule.Source.Network }}{{ if $rule.Source.Any }} (any){{ end }} | {{ $rule.Destination.Network }}{{ if $rule.Destination.Any }} (any){{ end }} | {{ $rule.Destination.Port }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---
@@ -148,7 +148,7 @@
 | # | Interface | Protocol | Source | Destination | Target | Source Port | Enabled | Description |
 |---|-----------|----------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Nat.Outbound.Rule }}
-| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.IPProtocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---

--- a/internal/templates/opnsense_report_comprehensive.md.tmpl
+++ b/internal/templates/opnsense_report_comprehensive.md.tmpl
@@ -129,10 +129,10 @@
 
 ## Firewall Rules
 
-| # | Action | Proto | Interface | Direction | State Type | Quick | Source | Destination | Dest Port | Target | Source Port | Enabled | Description |
-|---|--------|-------|-----------|-----------|------------|-------|--------|-------------|-----------|--------|-------------|---------|-------------|
+| # | Action | IP Ver | Proto | Interface | Direction | State Type | Quick | Source | Destination | Dest Port | Target | Source Port | Enabled | Description |
+|---|--------|--------|-------|-----------|-----------|------------|-------|--------|-------------|-----------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Type }} | {{ $rule.Protocol }} | {{ $rule.Interface }} | {{ $rule.Direction }} | {{ $rule.StateType }} | {{ formatBoolean $rule.Quick }} | {{ $rule.Source.Network }}{{ if $rule.Source.Any }} (any){{ end }} | {{ $rule.Destination.Network }}{{ if $rule.Destination.Any }} (any){{ end }} | {{ $rule.Destination.Port }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Interface }} | {{ $rule.Direction }} | {{ $rule.StateType }} | {{ formatBoolean $rule.Quick }} | {{ $rule.Source.Network }}{{ if $rule.Source.Any }} (any){{ end }} | {{ $rule.Destination.Network }}{{ if $rule.Destination.Any }} (any){{ end }} | {{ $rule.Destination.Port }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---
@@ -145,10 +145,10 @@
 
 ### NAT Rules
 
-| # | Interface | Protocol | Source | Destination | Target | Source Port | Enabled | Description |
-|---|-----------|----------|--------|-------------|--------|-------------|---------|-------------|
+| # | Interface | IP Ver | Protocol | Source | Destination | Target | Source Port | Enabled | Description |
+|---|-----------|--------|----------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Nat.Outbound.Rule }}
-| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ if $rule.Destination.Any }}any{{ else }}{{ $rule.Destination.Network }}{{ end }} | {{ $rule.Target }} | {{ $rule.SourcePort }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---


### PR DESCRIPTION
This pull request updates the firewall and NAT rules reporting to include both the IP version and the protocol in all relevant markdown tables and templates. It also enhances test coverage to ensure the protocol information is correctly displayed in generated reports.

**Firewall and NAT rules markdown output improvements:**

* Added a new "IP Ver" column and ensured the "Protocol" column is present in all firewall and NAT rules tables in the markdown report templates (`opnsense_report.md.tmpl`, `opnsense_report_comprehensive.md.tmpl`). The templates now display both the IP version and protocol for each rule. [[1]](diffhunk://#diff-cb1baaec59dd0a46c8541d422f638afd31d5ff18e62962113ba56cda6f3f44ffL40-R43) [[2]](diffhunk://#diff-cb1baaec59dd0a46c8541d422f638afd31d5ff18e62962113ba56cda6f3f44ffL54-R57) [[3]](diffhunk://#diff-6b4b7e5f29b3b6d84615b42382ef779099368c7943d9bdf4a5c9335facefa6a6L132-R135) [[4]](diffhunk://#diff-6b4b7e5f29b3b6d84615b42382ef779099368c7943d9bdf4a5c9335facefa6a6L148-R151)
* Updated the `buildSecuritySection` method in `markdown.go` to include the IP version and protocol fields in the generated markdown tables for firewall rules. [[1]](diffhunk://#diff-62c173fcb7134a471bd4b81356d9c6f41964f8980f154b0f54a4d9fa0ce066f0L282-R282) [[2]](diffhunk://#diff-62c173fcb7134a471bd4b81356d9c6f41964f8980f154b0f54a4d9fa0ce066f0R303)

**Test enhancements:**

* Modified and expanded tests in `markdown_test.go` to verify that both IP version and protocol information are present in the generated markdown output, including new test cases for various protocol values. [[1]](diffhunk://#diff-cb86953d833fc01e23e80853207212b49e623d610c36bf53b34ee808f1af46adL156-R165) [[2]](diffhunk://#diff-cb86953d833fc01e23e80853207212b49e623d610c36bf53b34ee808f1af46adL305-R366)