### PR TITLE
feat(markdown): enhance interface link formatting in markdown reports

### DIFF
--- a/internal/converter/markdown.go
+++ b/internal/converter/markdown.go
@@ -44,15 +44,16 @@ var ErrUnsupportedFormat = errors.New("unsupported format. Supported formats: ma
 
 // formatInterfacesAsLinks formats a list of interfaces as markdown links pointing to their respective sections.
 // Each interface name is converted to a clickable link that references the corresponding interface configuration section.
-// For table display, this returns the interface names with reference numbers that will be defined at the bottom.
+// The function returns inline markdown links (e.g., [wan](#wan-interface)), which the nao1215/markdown package
+// automatically converts to reference-style links when used in table cells.
 func formatInterfacesAsLinks(interfaces model.InterfaceList) string {
 	if interfaces.IsEmpty() {
 		return ""
 	}
 
-	// For table display, we return the interface names as-is
-	// The nao1215/markdown package will automatically create reference-style links
-	// when the markdown.Link function is used in table cells
+	// Create inline markdown links for each interface
+	// The nao1215/markdown package will automatically convert these to reference-style links
+	// when used in table cells (e.g., wan[1] with [1]: wan #wan-interface at the bottom)
 	links := make([]string, 0, len(interfaces))
 	for _, iface := range interfaces {
 		// Create anchor link to the interface section

--- a/internal/markdown/generator.go
+++ b/internal/markdown/generator.go
@@ -215,6 +215,25 @@ func createTemplateFuncMap() template.FuncMap {
 	funcMap["formatBooleanWithUnset"] = FormatBooleanWithUnset
 	funcMap["formatUnixTimestamp"] = FormatUnixTimestamp
 
+	// Add interface link formatting function
+	funcMap["formatInterfacesAsLinks"] = func(interfaces model.InterfaceList) string {
+		if interfaces.IsEmpty() {
+			return ""
+		}
+
+		links := make([]string, 0, len(interfaces))
+		for _, iface := range interfaces {
+			// Create anchor link to the interface section
+			anchor := "#" + strings.ToLower(iface) + "-interface"
+
+			// Use markdown link format
+			links = append(links, fmt.Sprintf("[%s](%s)", iface, anchor))
+		}
+
+		// Join links with comma and space for inline display in table
+		return strings.Join(links, ", ")
+	}
+
 	return funcMap
 }
 

--- a/internal/templates/opnsense_report.md.tmpl
+++ b/internal/templates/opnsense_report.md.tmpl
@@ -40,7 +40,7 @@
 | # | Interface | Action | IP Ver | Proto | Source | Destination | Target | Source Port | Enabled | Description |
 |---|-----------|--------|--------|-------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ formatInterfacesAsLinks $rule.Interface }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---

--- a/internal/templates/opnsense_report_comprehensive.md.tmpl
+++ b/internal/templates/opnsense_report_comprehensive.md.tmpl
@@ -143,14 +143,14 @@
 | # | Interface | Action | IP Ver | Proto | Source | Destination | Target | Source Port | Enabled | Description |
 |---|-----------|--------|--------|-------|--------|-------------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Interface }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ formatInterfacesAsLinks $rule.Interface }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Source.Network }} | {{ $rule.Destination.Network }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ### Detailed Firewall Rules
 | # | Action | IP Ver | Proto | Interface | Direction | State Type | Quick | Source | Destination | Dest Port | Target | Source Port | Enabled | Description |
 |---|--------|--------|-------|-----------|-----------|------------|-------|--------|-------------|-----------|--------|-------------|---------|-------------|
 {{- range $index, $rule := .Filter.Rule }}
-| {{ add $index 1 }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ $rule.Interface }} | {{ $rule.Direction }} | {{ $rule.StateType }} | {{ formatBoolean $rule.Quick }} | {{ $rule.Source.Network }}{{ if $rule.Source.Any }} (any){{ end }} | {{ $rule.Destination.Network }}{{ if $rule.Destination.Any }} (any){{ end }} | {{ $rule.Destination.Port }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
+| {{ add $index 1 }} | {{ $rule.Type }} | {{ $rule.IPProtocol }} | {{ $rule.Protocol }} | {{ formatInterfacesAsLinks $rule.Interface }} | {{ $rule.Direction }} | {{ $rule.StateType }} | {{ formatBoolean $rule.Quick }} | {{ $rule.Source.Network }}{{ if $rule.Source.Any }} (any){{ end }} | {{ $rule.Destination.Network }}{{ if $rule.Destination.Any }} (any){{ end }} | {{ $rule.Destination.Port }} | {{ if $rule.Target }}{{ $rule.Target }}{{ else }}-{{ end }} | {{ if $rule.SourcePort }}{{ $rule.SourcePort }}{{ else }}-{{ end }} | {{ formatBoolean (not $rule.Disabled) }} | {{ if $rule.Descr }}{{ $rule.Descr }}{{ else }}-{{ end }} |
 {{- end }}
 
 ---


### PR DESCRIPTION
This pull request enhances the Markdown export functionality for OPNsense configuration reports by improving how network interfaces are displayed in firewall rules tables. Specifically, it introduces dynamic, clickable Markdown links for interfaces, which reference their respective configuration sections. The changes also ensure that all interfaces (including dynamically named ones) get their own sections and that these improvements are thoroughly tested.

Key improvements include:

**Interface Link Formatting and Section Generation:**

* Added a new `formatInterfacesAsLinks` function to generate Markdown links for interface names, allowing users to click interface names in firewall tables and jump directly to their configuration sections. This function is used both in the main code and as a template helper. [[1]](diffhunk://#diff-62c173fcb7134a471bd4b81356d9c6f41964f8980f154b0f54a4d9fa0ce066f0R45-R68) [[2]](diffhunk://#diff-ff347554ae6f9c93be6c94e33f122544c3b58aa27414867d5cdc692d5c696a8fR218-R236)
* Updated the Markdown templates (`opnsense_report.md.tmpl`, `opnsense_report_comprehensive.md.tmpl`) to use the new link formatting for all interface columns in firewall rule tables, including detailed rule tables. [[1]](diffhunk://#diff-cb1baaec59dd0a46c8541d422f638afd31d5ff18e62962113ba56cda6f3f44ffL43-R43) [[2]](diffhunk://#diff-6b4b7e5f29b3b6d84615b42382ef779099368c7943d9bdf4a5c9335facefa6a6L146-R153)
* Modified the section generation logic to dynamically create a section for every interface present in the configuration, not just WAN and LAN, ensuring anchors for all interfaces referenced in the tables.

**Testing Enhancements:**

* Added comprehensive unit tests for the interface link formatting function, including cases for empty, single, multiple, and mixed-case interface lists.
* Extended integration tests to verify that interface links in generated Markdown and template output are correct, and that the corresponding interface sections/anchors are present.

**Minor Fixes:**

* Adjusted an assertion in the Markdown converter test to account for possible column truncation in table headers.

These changes collectively improve the usability and navigability of generated Markdown reports, making it easier for users to cross-reference firewall rules and interface configurations.