### PR TITLE
feat(tests): add comprehensive tests for MarkdownBuilder functionality

### DIFF
--- a/internal/converter/markdown.go
+++ b/internal/converter/markdown.go
@@ -9,8 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/EvilBit-Labs/opnDossier/internal/constants"
 	"github.com/EvilBit-Labs/opnDossier/internal/model"
 	"github.com/charmbracelet/glamour"
 	"github.com/nao1215/markdown"
@@ -19,11 +22,49 @@ import (
 // Constants for common values.
 const (
 	destinationAny = "any"
+	checkmark      = "✓"
+	xMark          = "✗"
 )
 
 // Converter is the interface for converting OPNsense configurations to markdown.
 type Converter interface {
 	ToMarkdown(ctx context.Context, opnsense *model.OpnSenseDocument) (string, error)
+}
+
+// ReportBuilder interface defines the contract for programmatic report generation.
+// This provides type-safe, compile-time guaranteed markdown generation.
+type ReportBuilder interface {
+	// Core section builders
+	BuildSystemSection(data *model.OpnSenseDocument) string
+	BuildNetworkSection(data *model.OpnSenseDocument) string
+	BuildSecuritySection(data *model.OpnSenseDocument) string
+	BuildServicesSection(data *model.OpnSenseDocument) string
+
+	// Shared component builders
+	BuildFirewallRulesTable(rules []model.Rule) *markdown.TableSet
+	BuildInterfaceTable(interfaces model.Interfaces) *markdown.TableSet
+	BuildUserTable(users []model.User) *markdown.TableSet
+	BuildGroupTable(groups []model.Group) *markdown.TableSet
+	BuildSysctlTable(sysctl []model.SysctlItem) *markdown.TableSet
+
+	// Report generation
+	BuildStandardReport(data *model.OpnSenseDocument) (string, error)
+	BuildComprehensiveReport(data *model.OpnSenseDocument) (string, error)
+}
+
+// MarkdownBuilder implements the ReportBuilder interface with comprehensive
+// programmatic markdown generation capabilities.
+type MarkdownBuilder struct {
+	generated   time.Time
+	toolVersion string
+}
+
+// NewMarkdownBuilder creates a new MarkdownBuilder instance.
+func NewMarkdownBuilder() *MarkdownBuilder {
+	return &MarkdownBuilder{
+		generated:   time.Now(),
+		toolVersion: constants.Version,
+	}
 }
 
 // MarkdownConverter is a markdown converter for OPNsense configurations.
@@ -65,6 +106,630 @@ func formatInterfacesAsLinks(interfaces model.InterfaceList) string {
 
 	// Join links with comma and space for inline display in table
 	return strings.Join(links, ", ")
+}
+
+// formatBoolean formats a boolean value for display in markdown tables.
+func formatBoolean(value string) string {
+	if value == "1" || value == "true" || value == "on" {
+		return checkmark
+	}
+	return xMark
+}
+
+// formatBooleanInverted formats a boolean value for display in markdown tables with inverted logic.
+// This is used for fields like "Disabled" where empty/0 means enabled and 1 means disabled.
+func formatBooleanInverted(value string) string {
+	if value == "1" || value == "true" || value == "on" {
+		return xMark
+	}
+	return checkmark
+}
+
+// formatIntBoolean formats an integer boolean value for display in markdown tables.
+func formatIntBoolean(value int) string {
+	if value == 1 {
+		return checkmark
+	}
+	return xMark
+}
+
+// formatIntBooleanWithUnset formats an integer boolean value with support for unset states.
+func formatIntBooleanWithUnset(value int) string {
+	if value == 0 {
+		return "unset"
+	}
+	return formatIntBoolean(value)
+}
+
+// formatStructBoolean formats a struct{} boolean value for display in markdown tables.
+func formatStructBoolean(_ struct{}) string {
+	// If the struct is present, it's considered enabled
+	return checkmark
+}
+
+// formatBool formats a boolean value for display in markdown tables.
+func formatBool(value bool) string {
+	if value {
+		return checkmark
+	}
+	return xMark
+}
+
+// getPowerModeDescription returns a human-readable description of power management modes.
+func getPowerModeDescription(mode string) string {
+	switch mode {
+	case "hadp":
+		return "Adaptive (hadp)"
+	case "maximum":
+		return "Maximum Performance (maximum)"
+	case "minimum":
+		return "Minimum Power (minimum)"
+	case "hiadaptive":
+		return "High Adaptive (hiadaptive)"
+	case "adaptive":
+		return "Adaptive (adaptive)"
+	default:
+		return mode
+	}
+}
+
+// BuildSystemSection builds the system configuration section.
+func (b *MarkdownBuilder) BuildSystemSection(data *model.OpnSenseDocument) string {
+	var buf bytes.Buffer
+	md := markdown.NewMarkdown(&buf)
+
+	sysConfig := data.SystemConfig()
+
+	md.H2("System Configuration")
+
+	// Basic Information
+	md.H3("Basic Information")
+	md.PlainTextf("%s: %s", markdown.Bold("Hostname"), sysConfig.System.Hostname)
+	md.PlainTextf("%s: %s", markdown.Bold("Domain"), sysConfig.System.Domain)
+
+	if sysConfig.System.Optimization != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Optimization"), sysConfig.System.Optimization)
+	}
+
+	if sysConfig.System.Timezone != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Timezone"), sysConfig.System.Timezone)
+	}
+
+	if sysConfig.System.Language != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Language"), sysConfig.System.Language)
+	}
+
+	// Web GUI Configuration
+	if sysConfig.System.WebGUI.Protocol != "" {
+		md.H3("Web GUI Configuration")
+		md.PlainTextf("%s: %s", markdown.Bold("Protocol"), sysConfig.System.WebGUI.Protocol)
+	}
+
+	// System Settings
+	md.H3("System Settings")
+	md.PlainTextf("%s: %s", markdown.Bold("DNS Allow Override"), formatIntBoolean(sysConfig.System.DNSAllowOverride))
+	md.PlainTextf("%s: %d", markdown.Bold("Next UID"), sysConfig.System.NextUID)
+	md.PlainTextf("%s: %d", markdown.Bold("Next GID"), sysConfig.System.NextGID)
+
+	if sysConfig.System.TimeServers != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Time Servers"), sysConfig.System.TimeServers)
+	}
+
+	if sysConfig.System.DNSServer != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("DNS Server"), sysConfig.System.DNSServer)
+	}
+
+	// Hardware Offloading
+	md.H3("Hardware Offloading")
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Disable NAT Reflection"),
+		formatBoolean(sysConfig.System.DisableNATReflection),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Use Virtual Terminal"),
+		formatIntBoolean(sysConfig.System.UseVirtualTerminal),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Disable Console Menu"),
+		formatStructBoolean(sysConfig.System.DisableConsoleMenu),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Disable VLAN HW Filter"),
+		formatIntBoolean(sysConfig.System.DisableVLANHWFilter),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Disable Checksum Offloading"),
+		formatIntBoolean(sysConfig.System.DisableChecksumOffloading),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Disable Segmentation Offloading"),
+		formatIntBoolean(sysConfig.System.DisableSegmentationOffloading),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Disable Large Receive Offloading"),
+		formatIntBoolean(sysConfig.System.DisableLargeReceiveOffloading),
+	)
+	md.PlainTextf("%s: %s", markdown.Bold("IPv6 Allow"), formatBoolean(sysConfig.System.IPv6Allow))
+
+	// Power Management
+	md.H3("Power Management")
+	md.PlainTextf("%s: %s", markdown.Bold("Powerd AC Mode"), getPowerModeDescription(sysConfig.System.PowerdACMode))
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Powerd Battery Mode"),
+		getPowerModeDescription(sysConfig.System.PowerdBatteryMode),
+	)
+	md.PlainTextf(
+		"%s: %s",
+		markdown.Bold("Powerd Normal Mode"),
+		getPowerModeDescription(sysConfig.System.PowerdNormalMode),
+	)
+
+	// System Features
+	md.H3("System Features")
+	md.PlainTextf("%s: %s", markdown.Bold("PF Share Forward"), formatIntBoolean(sysConfig.System.PfShareForward))
+	md.PlainTextf("%s: %s", markdown.Bold("LB Use Sticky"), formatIntBoolean(sysConfig.System.LbUseSticky))
+	md.PlainTextf("%s: %s", markdown.Bold("RRD Backup"), formatIntBooleanWithUnset(sysConfig.System.RrdBackup))
+	md.PlainTextf("%s: %s", markdown.Bold("Netflow Backup"), formatIntBooleanWithUnset(sysConfig.System.NetflowBackup))
+
+	// Bogons Configuration
+	if sysConfig.System.Bogons.Interval != "" {
+		md.H3("Bogons Configuration")
+		md.PlainTextf("%s: %s", markdown.Bold("Interval"), sysConfig.System.Bogons.Interval)
+	}
+
+	// SSH Configuration
+	if sysConfig.System.SSH.Group != "" {
+		md.H3("SSH Configuration")
+		md.PlainTextf("%s: %s", markdown.Bold("Group"), sysConfig.System.SSH.Group)
+	}
+
+	// Firmware Information
+	if sysConfig.System.Firmware.Version != "" {
+		md.H3("Firmware Information")
+		md.PlainTextf("%s: %s", markdown.Bold("Version"), sysConfig.System.Firmware.Version)
+	}
+
+	// System Tunables
+	if len(sysConfig.Sysctl) > 0 {
+		md.H3("System Tunables")
+		tableSet := b.BuildSysctlTable(sysConfig.Sysctl)
+		md.Table(*tableSet)
+	}
+
+	// Users
+	if len(sysConfig.System.User) > 0 {
+		md.H3("System Users")
+		tableSet := b.BuildUserTable(sysConfig.System.User)
+		md.Table(*tableSet)
+	}
+
+	// Groups
+	if len(sysConfig.System.Group) > 0 {
+		md.H3("System Groups")
+		tableSet := b.BuildGroupTable(sysConfig.System.Group)
+		md.Table(*tableSet)
+	}
+
+	return md.String()
+}
+
+// BuildNetworkSection builds the network configuration section.
+func (b *MarkdownBuilder) BuildNetworkSection(data *model.OpnSenseDocument) string {
+	var buf bytes.Buffer
+	md := markdown.NewMarkdown(&buf)
+
+	netConfig := data.NetworkConfig()
+
+	md.H2("Network Configuration")
+
+	// Interfaces table
+	md.H3("Interfaces")
+	tableSet := b.BuildInterfaceTable(netConfig.Interfaces)
+	md.Table(*tableSet)
+
+	// Individual interface details
+	for name, iface := range netConfig.Interfaces.Items {
+		sectionName := strings.ToUpper(name[:1]) + strings.ToLower(name[1:]) + " Interface"
+		md.H3(sectionName)
+		buildInterfaceDetails(md, iface)
+	}
+
+	return md.String()
+}
+
+// buildInterfaceDetails builds interface configuration details.
+func buildInterfaceDetails(md *markdown.Markdown, iface model.Interface) {
+	if iface.If != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Physical Interface"), iface.If)
+	}
+
+	if iface.Enable != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Enabled"), iface.Enable)
+	}
+
+	if iface.IPAddr != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("IPv4 Address"), iface.IPAddr)
+	}
+
+	if iface.Subnet != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("IPv4 Subnet"), iface.Subnet)
+	}
+
+	if iface.IPAddrv6 != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("IPv6 Address"), iface.IPAddrv6)
+	}
+
+	if iface.Subnetv6 != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("IPv6 Subnet"), iface.Subnetv6)
+	}
+
+	if iface.Gateway != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Gateway"), iface.Gateway)
+	}
+
+	if iface.MTU != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("MTU"), iface.MTU)
+	}
+
+	if iface.BlockPriv != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Block Private Networks"), iface.BlockPriv)
+	}
+
+	if iface.BlockBogons != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Block Bogon Networks"), iface.BlockBogons)
+	}
+}
+
+// BuildSecuritySection builds the security configuration section.
+func (b *MarkdownBuilder) BuildSecuritySection(data *model.OpnSenseDocument) string {
+	var buf bytes.Buffer
+	md := markdown.NewMarkdown(&buf)
+
+	secConfig := data.SecurityConfig()
+
+	md.H2("Security Configuration")
+
+	// NAT Configuration
+	md.H3("NAT Configuration")
+
+	if secConfig.Nat.Outbound.Mode != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Outbound NAT Mode"), secConfig.Nat.Outbound.Mode)
+	}
+
+	// NAT Summary
+	natSummary := data.NATSummary()
+	if natSummary.Mode != "" {
+		md.H4("NAT Summary")
+		md.PlainTextf("%s: %s", markdown.Bold("NAT Mode"), natSummary.Mode)
+		md.PlainTextf("%s: %s", markdown.Bold("NAT Reflection"), formatBool(natSummary.ReflectionDisabled))
+		md.PlainTextf("%s: %s", markdown.Bold("Port Forward State Sharing"), formatBool(natSummary.PfShareForward))
+		md.PlainTextf("%s: %d", markdown.Bold("Outbound Rules"), len(natSummary.OutboundRules))
+
+		if natSummary.ReflectionDisabled {
+			md.PlainText(
+				"**Security Note**: NAT reflection is properly disabled, preventing potential security issues where internal clients can access internal services via external IP addresses.",
+			)
+		} else {
+			md.PlainText("**⚠️ Security Warning**: NAT reflection is enabled, which may allow internal clients to access internal services via external IP addresses. Consider disabling if not needed.")
+		}
+	}
+
+	// Firewall Rules
+	rules := data.FilterRules()
+	if len(rules) > 0 {
+		md.H3("Firewall Rules")
+		tableSet := b.BuildFirewallRulesTable(rules)
+		md.Table(*tableSet)
+	}
+
+	return md.String()
+}
+
+// BuildServicesSection builds the service configuration section.
+func (b *MarkdownBuilder) BuildServicesSection(data *model.OpnSenseDocument) string {
+	var buf bytes.Buffer
+	md := markdown.NewMarkdown(&buf)
+
+	svcConfig := data.ServiceConfig()
+
+	md.H2("Service Configuration")
+
+	// DHCP Server
+	md.H3("DHCP Server")
+
+	if lanDhcp, ok := svcConfig.Dhcpd.Get("lan"); ok && lanDhcp.Enable != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("LAN DHCP Enabled"), formatBoolean(lanDhcp.Enable))
+
+		if lanDhcp.Range.From != "" && lanDhcp.Range.To != "" {
+			md.PlainTextf("%s: %s - %s", markdown.Bold("LAN DHCP Range"), lanDhcp.Range.From, lanDhcp.Range.To)
+		}
+	}
+
+	if wanDhcp, ok := svcConfig.Dhcpd.Get("wan"); ok && wanDhcp.Enable != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("WAN DHCP Enabled"), formatBoolean(wanDhcp.Enable))
+	}
+
+	// DNS Resolver (Unbound)
+	md.H3("DNS Resolver (Unbound)")
+
+	if svcConfig.Unbound.Enable != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Enabled"), formatBoolean(svcConfig.Unbound.Enable))
+	}
+
+	// SNMP
+	md.H3("SNMP")
+
+	if svcConfig.Snmpd.SysLocation != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("System Location"), svcConfig.Snmpd.SysLocation)
+	}
+
+	if svcConfig.Snmpd.SysContact != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("System Contact"), svcConfig.Snmpd.SysContact)
+	}
+
+	if svcConfig.Snmpd.ROCommunity != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Read-Only Community"), svcConfig.Snmpd.ROCommunity)
+	}
+
+	// NTP
+	md.H3("NTP")
+
+	if svcConfig.Ntpd.Prefer != "" {
+		md.PlainTextf("%s: %s", markdown.Bold("Preferred Server"), svcConfig.Ntpd.Prefer)
+	}
+
+	// Load Balancer
+	if len(svcConfig.LoadBalancer.MonitorType) > 0 {
+		md.H3("Load Balancer Monitors")
+
+		headers := []string{"Name", "Type", "Description"}
+		rows := make([][]string, 0, len(svcConfig.LoadBalancer.MonitorType))
+
+		for _, monitor := range svcConfig.LoadBalancer.MonitorType {
+			rows = append(rows, []string{monitor.Name, monitor.Type, monitor.Descr})
+		}
+
+		tableSet := markdown.TableSet{
+			Header: headers,
+			Rows:   rows,
+		}
+		md.Table(tableSet)
+	}
+
+	return md.String()
+}
+
+// BuildFirewallRulesTable builds a table of firewall rules.
+func (b *MarkdownBuilder) BuildFirewallRulesTable(rules []model.Rule) *markdown.TableSet {
+	headers := []string{
+		"#",
+		"Interface",
+		"Action",
+		"IP Ver",
+		"Proto",
+		"Source",
+		"Destination",
+		"Target",
+		"Source Port",
+		"Enabled",
+		"Description",
+	}
+
+	rows := make([][]string, 0, len(rules))
+	for i, rule := range rules {
+		source := rule.Source.Network
+		if source == "" {
+			source = destinationAny
+		}
+
+		dest := rule.Destination.Network
+		if dest == "" {
+			dest = destinationAny
+		}
+
+		interfaceLinks := formatInterfacesAsLinks(rule.Interface)
+
+		rows = append(rows, []string{
+			strconv.Itoa(i + 1),
+			interfaceLinks,
+			rule.Type,
+			rule.IPProtocol,
+			rule.Protocol,
+			source,
+			dest,
+			rule.Target,
+			rule.SourcePort,
+			formatBooleanInverted(rule.Disabled),
+			rule.Descr,
+		})
+	}
+
+	return &markdown.TableSet{
+		Header: headers,
+		Rows:   rows,
+	}
+}
+
+// BuildInterfaceTable builds a table of network interfaces.
+func (b *MarkdownBuilder) BuildInterfaceTable(interfaces model.Interfaces) *markdown.TableSet {
+	headers := []string{"Name", "Description", "IP Address", "CIDR", "Enabled"}
+
+	rows := make([][]string, 0, len(interfaces.Items))
+	for name, iface := range interfaces.Items {
+		description := iface.Descr
+		if description == "" {
+			description = iface.If
+		}
+
+		cidr := ""
+		if iface.Subnet != "" {
+			cidr = "/" + iface.Subnet
+		}
+
+		rows = append(rows, []string{
+			fmt.Sprintf("`%s`", name),
+			fmt.Sprintf("`%s`", description),
+			fmt.Sprintf("`%s`", iface.IPAddr),
+			cidr,
+			formatBoolean(iface.Enable),
+		})
+	}
+
+	return &markdown.TableSet{
+		Header: headers,
+		Rows:   rows,
+	}
+}
+
+// BuildUserTable builds a table of system users.
+func (b *MarkdownBuilder) BuildUserTable(users []model.User) *markdown.TableSet {
+	headers := []string{"Name", "Description", "Group", "Scope"}
+
+	rows := make([][]string, 0, len(users))
+	for _, user := range users {
+		rows = append(rows, []string{user.Name, user.Descr, user.Groupname, user.Scope})
+	}
+
+	return &markdown.TableSet{
+		Header: headers,
+		Rows:   rows,
+	}
+}
+
+// BuildGroupTable builds a table of system groups.
+func (b *MarkdownBuilder) BuildGroupTable(groups []model.Group) *markdown.TableSet {
+	headers := []string{"Name", "Description", "Scope"}
+
+	rows := make([][]string, 0, len(groups))
+	for _, group := range groups {
+		rows = append(rows, []string{group.Name, group.Description, group.Scope})
+	}
+
+	return &markdown.TableSet{
+		Header: headers,
+		Rows:   rows,
+	}
+}
+
+// BuildSysctlTable builds a table of system tunables.
+func (b *MarkdownBuilder) BuildSysctlTable(sysctl []model.SysctlItem) *markdown.TableSet {
+	headers := []string{"Tunable", "Value", "Description"}
+
+	rows := make([][]string, 0, len(sysctl))
+	for _, item := range sysctl {
+		rows = append(rows, []string{item.Tunable, item.Value, item.Descr})
+	}
+
+	return &markdown.TableSet{
+		Header: headers,
+		Rows:   rows,
+	}
+}
+
+// BuildStandardReport builds a standard markdown report.
+func (b *MarkdownBuilder) BuildStandardReport(data *model.OpnSenseDocument) (string, error) {
+	if data == nil {
+		return "", ErrNilOpnSenseDocument
+	}
+
+	var buf bytes.Buffer
+	md := markdown.NewMarkdown(&buf)
+
+	// Main title
+	md.H1("OPNsense Configuration Summary")
+
+	// System Information
+	md.H2("System Information")
+	md.PlainTextf("- **Hostname**: %s", data.System.Hostname)
+	md.PlainTextf("- **Domain**: %s", data.System.Domain)
+	md.PlainTextf("- **Platform**: OPNsense %s", data.System.Firmware.Version)
+	md.PlainTextf("- **Generated On**: %s", b.generated.Format("2006-01-02 15:04:05"))
+	md.PlainTextf("- **Parsed By**: opnDossier v%s", b.toolVersion)
+
+	// Table of Contents
+	md.H2("Table of Contents")
+	md.PlainText("- [System Configuration](#system-configuration)")
+	md.PlainText("- [Interfaces](#interfaces)")
+	md.PlainText("- [Firewall Rules](#firewall-rules)")
+	md.PlainText("- [NAT Configuration](#nat-configuration)")
+	md.PlainText("- [DHCP Services](#dhcp-services)")
+	md.PlainText("- [DNS Resolver](#dns-resolver)")
+	md.PlainText("- [System Users](#system-users)")
+	md.PlainText("- [Services & Daemons](#services--daemons)")
+	md.PlainText("- [System Tunables](#system-tunables)")
+
+	// Build sections
+	md.PlainText(b.BuildSystemSection(data))
+	md.PlainText(b.BuildNetworkSection(data))
+	md.PlainText(b.BuildSecuritySection(data))
+	md.PlainText(b.BuildServicesSection(data))
+
+	// Add system users and tunables sections
+	sysConfig := data.SystemConfig()
+
+	if len(sysConfig.System.User) > 0 {
+		md.H2("System Users")
+		tableSet := b.BuildUserTable(sysConfig.System.User)
+		md.Table(*tableSet)
+	}
+
+	if len(sysConfig.Sysctl) > 0 {
+		md.H2("System Tunables")
+		tableSet := b.BuildSysctlTable(sysConfig.Sysctl)
+		md.Table(*tableSet)
+	}
+
+	return md.String(), nil
+}
+
+// BuildComprehensiveReport builds a comprehensive markdown report.
+func (b *MarkdownBuilder) BuildComprehensiveReport(data *model.OpnSenseDocument) (string, error) {
+	if data == nil {
+		return "", ErrNilOpnSenseDocument
+	}
+
+	var buf bytes.Buffer
+	md := markdown.NewMarkdown(&buf)
+
+	// Main title
+	md.H1("OPNsense Configuration Summary")
+
+	// System Information
+	md.H2("System Information")
+	md.PlainTextf("- **Hostname**: %s", data.System.Hostname)
+	md.PlainTextf("- **Domain**: %s", data.System.Domain)
+	md.PlainTextf("- **Platform**: OPNsense %s", data.System.Firmware.Version)
+	md.PlainTextf("- **Generated On**: %s", b.generated.Format("2006-01-02 15:04:05"))
+	md.PlainTextf("- **Parsed By**: opnDossier v%s", b.toolVersion)
+
+	// Table of Contents
+	md.H2("Table of Contents")
+	md.PlainText("- [System Configuration](#system-configuration)")
+	md.PlainText("- [Interfaces](#interfaces)")
+	md.PlainText("- [Firewall Rules](#firewall-rules)")
+	md.PlainText("- [NAT Configuration](#nat-configuration)")
+	md.PlainText("- [DHCP Services](#dhcp-services)")
+	md.PlainText("- [DNS Resolver](#dns-resolver)")
+	md.PlainText("- [System Users](#system-users)")
+	md.PlainText("- [System Groups](#system-groups)")
+	md.PlainText("- [Services & Daemons](#services--daemons)")
+	md.PlainText("- [System Tunables](#system-tunables)")
+
+	// Build comprehensive sections
+	md.PlainText(b.BuildSystemSection(data))
+	md.PlainText(b.BuildNetworkSection(data))
+	md.PlainText(b.BuildSecuritySection(data))
+	md.PlainText(b.BuildServicesSection(data))
+
+	return md.String(), nil
 }
 
 // ToMarkdown converts an OPNsense configuration to markdown.
@@ -232,14 +897,14 @@ func (c *MarkdownConverter) buildNetworkSection(md *markdown.Markdown, opnsense 
 	md.H3("WAN Interface")
 
 	if wan, ok := netConfig.Interfaces.Wan(); ok {
-		c.buildInterfaceDetails(md, wan)
+		buildInterfaceDetails(md, wan)
 	}
 
 	// LAN Interface - the H3 creates an implicit anchor #lan-interface
 	md.H3("LAN Interface")
 
 	if lan, ok := netConfig.Interfaces.Lan(); ok {
-		c.buildInterfaceDetails(md, lan)
+		buildInterfaceDetails(md, lan)
 	}
 
 	// Add other interfaces dynamically if they exist
@@ -249,51 +914,8 @@ func (c *MarkdownConverter) buildNetworkSection(md *markdown.Markdown, opnsense 
 			// Use proper case conversion for interface names
 			sectionName := strings.ToUpper(name[:1]) + strings.ToLower(name[1:]) + " Interface"
 			md.H3(sectionName)
-			c.buildInterfaceDetails(md, iface)
+			buildInterfaceDetails(md, iface)
 		}
-	}
-}
-
-// buildInterfaceDetails builds interface configuration details.
-func (c *MarkdownConverter) buildInterfaceDetails(md *markdown.Markdown, iface model.Interface) {
-	if iface.If != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("Physical Interface"), iface.If)
-	}
-
-	if iface.Enable != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("Enabled"), iface.Enable)
-	}
-
-	if iface.IPAddr != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("IPv4 Address"), iface.IPAddr)
-	}
-
-	if iface.Subnet != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("IPv4 Subnet"), iface.Subnet)
-	}
-
-	if iface.IPAddrv6 != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("IPv6 Address"), iface.IPAddrv6)
-	}
-
-	if iface.Subnetv6 != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("IPv6 Subnet"), iface.Subnetv6)
-	}
-
-	if iface.Gateway != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("Gateway"), iface.Gateway)
-	}
-
-	if iface.MTU != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("MTU"), iface.MTU)
-	}
-
-	if iface.BlockPriv != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("Block Private Networks"), iface.BlockPriv)
-	}
-
-	if iface.BlockBogons != "" {
-		md.PlainTextf("%s: %s", markdown.Bold("Block Bogon Networks"), iface.BlockBogons)
 	}
 }
 

--- a/internal/converter/markdown_builder_test.go
+++ b/internal/converter/markdown_builder_test.go
@@ -1,0 +1,1652 @@
+package converter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/EvilBit-Labs/opnDossier/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMarkdownBuilder(t *testing.T) {
+	builder := NewMarkdownBuilder()
+	assert.NotNil(t, builder)
+	assert.NotZero(t, builder.generated)
+	assert.NotEmpty(t, builder.toolVersion)
+}
+
+func TestMarkdownBuilder_BuildSystemSection(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Create test data with NAT reflection disabled
+	data := createComprehensiveTestData()
+	data.System.DisableNATReflection = "1" // Override to disable NAT reflection
+
+	result := builder.BuildSystemSection(data)
+
+	// Verify the result contains expected sections
+	assert.Contains(t, result, "System Configuration")
+	assert.Contains(t, result, "Basic Information")
+	assert.Contains(t, result, "Web GUI Configuration")
+	assert.Contains(t, result, "System Settings")
+	assert.Contains(t, result, "Hardware Offloading")
+	assert.Contains(t, result, "Power Management")
+	assert.Contains(t, result, "System Features")
+	assert.Contains(t, result, "Bogons Configuration")
+	assert.Contains(t, result, "SSH Configuration")
+	assert.Contains(t, result, "Firmware Information")
+	assert.Contains(t, result, "System Tunables")
+	assert.Contains(t, result, "System Users")
+	assert.Contains(t, result, "System Groups")
+
+	// Verify specific values
+	assert.Contains(t, result, "test-host")
+	assert.Contains(t, result, "test.local")
+	assert.Contains(t, result, "normal")
+	assert.Contains(t, result, "UTC")
+	assert.Contains(t, result, "en_US")
+	assert.Contains(t, result, "https")
+	assert.Contains(t, result, "wheel")
+	assert.Contains(t, result, "23.1.1")
+	assert.Contains(t, result, "daily")
+	assert.Contains(t, result, "net.inet.ip.forwarding")
+	assert.Contains(t, result, "admin")
+}
+
+func TestMarkdownBuilder_BuildNetworkSection(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Create test data with interfaces
+	data := &model.OpnSenseDocument{
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:          "em0",
+					Enable:      "1",
+					IPAddr:      "192.168.1.1",
+					Subnet:      "24",
+					Gateway:     "192.168.1.254",
+					MTU:         "1500",
+					BlockPriv:   "1",
+					BlockBogons: "1",
+					Descr:       "WAN Interface",
+				},
+				"lan": {
+					If:          "em1",
+					Enable:      "1",
+					IPAddr:      "10.0.0.1",
+					Subnet:      "24",
+					Gateway:     "",
+					MTU:         "1500",
+					BlockPriv:   "0",
+					BlockBogons: "0",
+					Descr:       "LAN Interface",
+				},
+			},
+		},
+	}
+
+	result := builder.BuildNetworkSection(data)
+
+	// Verify the result contains expected sections
+	assert.Contains(t, result, "Network Configuration")
+	assert.Contains(t, result, "Interfaces")
+	assert.Contains(t, result, "Wan Interface")
+	assert.Contains(t, result, "Lan Interface")
+
+	// Verify interface details
+	assert.Contains(t, result, "em0")
+	assert.Contains(t, result, "em1")
+	assert.Contains(t, result, "192.168.1.1")
+	assert.Contains(t, result, "10.0.0.1")
+	assert.Contains(t, result, "WAN Interface")
+	assert.Contains(t, result, "LAN Interface")
+}
+
+func TestMarkdownBuilder_BuildSecuritySection(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Create test data with security configuration
+	data := &model.OpnSenseDocument{
+		Nat: model.Nat{
+			Outbound: model.Outbound{
+				Mode: "automatic",
+			},
+		},
+		Filter: model.Filter{
+			Rule: []model.Rule{
+				{
+					Type:       "pass",
+					Descr:      "Allow LAN to WAN",
+					Interface:  model.InterfaceList{"lan"},
+					IPProtocol: "inet",
+					Protocol:   "tcp",
+					Source: model.Source{
+						Network: "lan",
+					},
+					Destination: model.Destination{
+						Network: "any",
+					},
+					Target:     "",
+					SourcePort: "",
+					Disabled:   "",
+				},
+				{
+					Type:       "block",
+					Descr:      "Block all",
+					Interface:  model.InterfaceList{"wan"},
+					IPProtocol: "inet",
+					Protocol:   "any",
+					Source: model.Source{
+						Network: "any",
+					},
+					Destination: model.Destination{
+						Network: "any",
+					},
+					Target:     "",
+					SourcePort: "",
+					Disabled:   "",
+				},
+			},
+		},
+	}
+
+	result := builder.BuildSecuritySection(data)
+
+	// Verify the result contains expected sections
+	assert.Contains(t, result, "Security Configuration")
+	assert.Contains(t, result, "NAT Configuration")
+	assert.Contains(t, result, "Firewall Rules")
+
+	// Verify NAT configuration
+	assert.Contains(t, result, "automatic")
+
+	// Verify firewall rules
+	assert.Contains(t, result, "Allow LAN to WAN")
+	assert.Contains(t, result, "Block all")
+	assert.Contains(t, result, "pass")
+	assert.Contains(t, result, "block")
+	assert.Contains(t, result, "lan")
+	assert.Contains(t, result, "wan")
+}
+
+func TestMarkdownBuilder_BuildServicesSection(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Create test data with services configuration
+	data := &model.OpnSenseDocument{
+		Dhcpd: model.Dhcpd{
+			Items: map[string]model.DhcpdInterface{
+				"lan": {
+					Enable: "1",
+					Range: model.Range{
+						From: "10.0.0.100",
+						To:   "10.0.0.200",
+					},
+				},
+				"wan": {
+					Enable: "1",
+				},
+			},
+		},
+		Unbound: model.Unbound{
+			Enable: "1",
+		},
+		Snmpd: model.Snmpd{
+			SysLocation: "Data Center",
+			SysContact:  "admin@example.com",
+			ROCommunity: "public",
+		},
+		Ntpd: model.Ntpd{
+			Prefer: "pool.ntp.org",
+		},
+		LoadBalancer: model.LoadBalancer{
+			MonitorType: []model.MonitorType{
+				{
+					Name:  "http-monitor",
+					Type:  "http",
+					Descr: "HTTP Health Check",
+				},
+			},
+		},
+	}
+
+	result := builder.BuildServicesSection(data)
+
+	// Verify the result contains expected sections
+	assert.Contains(t, result, "Service Configuration")
+	assert.Contains(t, result, "DHCP Server")
+	assert.Contains(t, result, "DNS Resolver (Unbound)")
+	assert.Contains(t, result, "SNMP")
+	assert.Contains(t, result, "NTP")
+	assert.Contains(t, result, "Load Balancer Monitors")
+
+	// Verify service details
+	assert.Contains(t, result, "10.0.0.100")
+	assert.Contains(t, result, "10.0.0.200")
+	assert.Contains(t, result, "Data Center")
+	assert.Contains(t, result, "admin@example.com")
+	assert.Contains(t, result, "public")
+	assert.Contains(t, result, "pool.ntp.org")
+	assert.Contains(t, result, "http-monitor")
+	assert.Contains(t, result, "HTTP Health Check")
+}
+
+func TestMarkdownBuilder_BuildFirewallRulesTable(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	rules := []model.Rule{
+		{
+			Type:       "pass",
+			Descr:      "Allow LAN to WAN",
+			Interface:  model.InterfaceList{"lan"},
+			IPProtocol: "inet",
+			Protocol:   "tcp",
+			Source: model.Source{
+				Network: "lan",
+			},
+			Destination: model.Destination{
+				Network: "any",
+			},
+			Target:     "",
+			SourcePort: "80",
+			Disabled:   "",
+		},
+	}
+
+	tableSet := builder.BuildFirewallRulesTable(rules)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 11)
+	assert.Len(t, tableSet.Rows, 1)
+
+	// Verify headers
+	expectedHeaders := []string{
+		"#",
+		"Interface",
+		"Action",
+		"IP Ver",
+		"Proto",
+		"Source",
+		"Destination",
+		"Target",
+		"Source Port",
+		"Enabled",
+		"Description",
+	}
+	assert.Equal(t, expectedHeaders, tableSet.Header)
+
+	// Verify first row
+	row := tableSet.Rows[0]
+	assert.Equal(t, "1", row[0])                 // #
+	assert.Contains(t, row[1], "lan")            // Interface (with link)
+	assert.Equal(t, "pass", row[2])              // Action
+	assert.Equal(t, "inet", row[3])              // IP Ver
+	assert.Equal(t, "tcp", row[4])               // Proto
+	assert.Equal(t, "lan", row[5])               // Source
+	assert.Equal(t, "any", row[6])               // Destination
+	assert.Empty(t, row[7])                      // Target
+	assert.Equal(t, "80", row[8])                // Source Port
+	assert.Equal(t, "✓", row[9])                 // Enabled
+	assert.Equal(t, "Allow LAN to WAN", row[10]) // Description
+}
+
+func TestMarkdownBuilder_BuildInterfaceTable(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	interfaces := model.Interfaces{
+		Items: map[string]model.Interface{
+			"wan": {
+				If:     "em0",
+				Enable: "1",
+				IPAddr: "192.168.1.1",
+				Subnet: "24",
+				Descr:  "WAN Interface",
+			},
+			"lan": {
+				If:     "em1",
+				Enable: "1",
+				IPAddr: "10.0.0.1",
+				Subnet: "24",
+				Descr:  "LAN Interface",
+			},
+		},
+	}
+
+	tableSet := builder.BuildInterfaceTable(interfaces)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 5)
+	assert.Len(t, tableSet.Rows, 2)
+
+	// Verify headers
+	expectedHeaders := []string{"Name", "Description", "IP Address", "CIDR", "Enabled"}
+	assert.Equal(t, expectedHeaders, tableSet.Header)
+
+	// Verify rows contain expected data
+	rowData := make(map[string][]string)
+	for _, row := range tableSet.Rows {
+		rowData[row[0]] = row
+	}
+
+	// Check WAN interface
+	wanRow := rowData["`wan`"]
+	assert.NotNil(t, wanRow)
+	assert.Equal(t, "`WAN Interface`", wanRow[1])
+	assert.Equal(t, "`192.168.1.1`", wanRow[2])
+	assert.Equal(t, "/24", wanRow[3])
+	assert.Equal(t, "✓", wanRow[4])
+
+	// Check LAN interface
+	lanRow := rowData["`lan`"]
+	assert.NotNil(t, lanRow)
+	assert.Equal(t, "`LAN Interface`", lanRow[1])
+	assert.Equal(t, "`10.0.0.1`", lanRow[2])
+	assert.Equal(t, "/24", lanRow[3])
+	assert.Equal(t, "✓", lanRow[4])
+}
+
+func TestMarkdownBuilder_BuildUserTable(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	users := []model.User{
+		{
+			Name:      "admin",
+			Descr:     "Administrator",
+			Groupname: "wheel",
+			Scope:     "system",
+		},
+		{
+			Name:      "user1",
+			Descr:     "Regular User",
+			Groupname: "users",
+			Scope:     "local",
+		},
+	}
+
+	tableSet := builder.BuildUserTable(users)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 4)
+	assert.Len(t, tableSet.Rows, 2)
+
+	// Verify headers
+	expectedHeaders := []string{"Name", "Description", "Group", "Scope"}
+	assert.Equal(t, expectedHeaders, tableSet.Header)
+
+	// Verify first row
+	row := tableSet.Rows[0]
+	assert.Equal(t, "admin", row[0])
+	assert.Equal(t, "Administrator", row[1])
+	assert.Equal(t, "wheel", row[2])
+	assert.Equal(t, "system", row[3])
+}
+
+func TestMarkdownBuilder_BuildGroupTable(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	groups := []model.Group{
+		{
+			Name:        "wheel",
+			Description: "Wheel group",
+			Scope:       "system",
+		},
+		{
+			Name:        "users",
+			Description: "Regular users",
+			Scope:       "local",
+		},
+	}
+
+	tableSet := builder.BuildGroupTable(groups)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 3)
+	assert.Len(t, tableSet.Rows, 2)
+
+	// Verify headers
+	expectedHeaders := []string{"Name", "Description", "Scope"}
+	assert.Equal(t, expectedHeaders, tableSet.Header)
+
+	// Verify first row
+	row := tableSet.Rows[0]
+	assert.Equal(t, "wheel", row[0])
+	assert.Equal(t, "Wheel group", row[1])
+	assert.Equal(t, "system", row[2])
+}
+
+func TestMarkdownBuilder_BuildSysctlTable(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	sysctl := []model.SysctlItem{
+		{
+			Tunable: "net.inet.ip.forwarding",
+			Value:   "1",
+			Descr:   "Enable IP forwarding",
+		},
+		{
+			Tunable: "net.inet.tcp.always_keepalive",
+			Value:   "0",
+			Descr:   "Disable TCP keepalive",
+		},
+	}
+
+	tableSet := builder.BuildSysctlTable(sysctl)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 3)
+	assert.Len(t, tableSet.Rows, 2)
+
+	// Verify headers
+	expectedHeaders := []string{"Tunable", "Value", "Description"}
+	assert.Equal(t, expectedHeaders, tableSet.Header)
+
+	// Verify first row
+	row := tableSet.Rows[0]
+	assert.Equal(t, "net.inet.ip.forwarding", row[0])
+	assert.Equal(t, "1", row[1])
+	assert.Equal(t, "Enable IP forwarding", row[2])
+}
+
+func TestMarkdownBuilder_BuildStandardReport(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			Firmware: model.Firmware{
+				Version: "23.1.1",
+			},
+		},
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:     "em0",
+					Enable: "1",
+					IPAddr: "192.168.1.1",
+					Subnet: "24",
+				},
+			},
+		},
+	}
+
+	result, err := builder.BuildStandardReport(data)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	// Verify report structure
+	assert.Contains(t, result, "OPNsense Configuration Summary")
+	assert.Contains(t, result, "System Information")
+	assert.Contains(t, result, "Table of Contents")
+	assert.Contains(t, result, "Interfaces")
+	assert.Contains(t, result, "Firewall Rules")
+	assert.Contains(t, result, "NAT Configuration")
+	assert.Contains(t, result, "DHCP Services")
+	assert.Contains(t, result, "DNS Resolver")
+	assert.Contains(t, result, "System Users")
+	assert.Contains(t, result, "Services & Daemons")
+	assert.Contains(t, result, "System Tunables")
+
+	// Verify data
+	assert.Contains(t, result, "test-host")
+	assert.Contains(t, result, "test.local")
+	assert.Contains(t, result, "23.1.1")
+	assert.Contains(t, result, "192.168.1.1")
+}
+
+func TestMarkdownBuilder_BuildComprehensiveReport(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			Firmware: model.Firmware{
+				Version: "23.1.1",
+			},
+		},
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:     "em0",
+					Enable: "1",
+					IPAddr: "192.168.1.1",
+					Subnet: "24",
+				},
+			},
+		},
+	}
+
+	result, err := builder.BuildComprehensiveReport(data)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	// Verify report structure
+	assert.Contains(t, result, "OPNsense Configuration Summary")
+	assert.Contains(t, result, "System Information")
+	assert.Contains(t, result, "Table of Contents")
+	assert.Contains(t, result, "System Configuration")
+	assert.Contains(t, result, "Interfaces")
+	assert.Contains(t, result, "Firewall Rules")
+	assert.Contains(t, result, "NAT Configuration")
+	assert.Contains(t, result, "DHCP Services")
+	assert.Contains(t, result, "DNS Resolver")
+	assert.Contains(t, result, "System Users")
+	assert.Contains(t, result, "System Groups")
+	assert.Contains(t, result, "Services & Daemons")
+	assert.Contains(t, result, "System Tunables")
+
+	// Verify data
+	assert.Contains(t, result, "test-host")
+	assert.Contains(t, result, "test.local")
+	assert.Contains(t, result, "23.1.1")
+	assert.Contains(t, result, "192.168.1.1")
+}
+
+func TestMarkdownBuilder_BuildStandardReport_NilData(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	result, err := builder.BuildStandardReport(nil)
+
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, ErrNilOpnSenseDocument, err)
+}
+
+func TestMarkdownBuilder_BuildComprehensiveReport_NilData(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	result, err := builder.BuildComprehensiveReport(nil)
+
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, ErrNilOpnSenseDocument, err)
+}
+
+func TestFormatBoolean(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"true value", "1", "✓"},
+		{"true string", "true", "✓"},
+		{"on value", "on", "✓"},
+		{"false value", "0", "✗"},
+		{"false string", "false", "✗"},
+		{"empty string", "", "✗"},
+		{"random string", "random", "✗"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatBoolean(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatIntBoolean(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{"true value", 1, "✓"},
+		{"false value", 0, "✗"},
+		{"negative value", -1, "✗"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatIntBoolean(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    bool
+		expected string
+	}{
+		{"true value", true, "✓"},
+		{"false value", false, "✗"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatBool(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetPowerModeDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"hadp", "hadp", "Adaptive (hadp)"},
+		{"maximum", "maximum", "Maximum Performance (maximum)"},
+		{"minimum", "minimum", "Minimum Power (minimum)"},
+		{"hiadaptive", "hiadaptive", "High Adaptive (hiadaptive)"},
+		{"adaptive", "adaptive", "Adaptive (adaptive)"},
+		{"unknown", "unknown", "unknown"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPowerModeDescription(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatBooleanInverted(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "true_value",
+			input:    "1",
+			expected: "✗",
+		},
+		{
+			name:     "true_string",
+			input:    "true",
+			expected: "✗",
+		},
+		{
+			name:     "on_value",
+			input:    "on",
+			expected: "✗",
+		},
+		{
+			name:     "false_value",
+			input:    "0",
+			expected: "✓",
+		},
+		{
+			name:     "false_string",
+			input:    "false",
+			expected: "✓",
+		},
+		{
+			name:     "empty_string",
+			input:    "",
+			expected: "✓",
+		},
+		{
+			name:     "random_string",
+			input:    "random",
+			expected: "✓",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatBooleanInverted(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildFirewallRulesTable_EdgeCases(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	tests := []struct {
+		name  string
+		rules []model.Rule
+	}{
+		{
+			name:  "empty_rules",
+			rules: []model.Rule{},
+		},
+		{
+			name: "rules_with_empty_networks",
+			rules: []model.Rule{
+				{
+					Type:        "pass",
+					Interface:   model.InterfaceList{"lan"},
+					IPProtocol:  "inet",
+					Protocol:    "tcp",
+					Source:      model.Source{Network: ""},
+					Destination: model.Destination{Network: ""},
+					Descr:       "Test rule",
+				},
+			},
+		},
+		{
+			name: "rules_with_nil_interface",
+			rules: []model.Rule{
+				{
+					Type:        "pass",
+					Interface:   nil,
+					IPProtocol:  "inet",
+					Protocol:    "tcp",
+					Source:      model.Source{Network: "lan"},
+					Destination: model.Destination{Network: "any"},
+					Descr:       "Test rule",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFirewallRulesTable(tt.rules)
+			assert.NotNil(t, result)
+			assert.Len(t, result.Header, 11) // Should have 11 headers
+		})
+	}
+}
+
+func TestBuildStandardReport_EdgeCases(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	tests := []struct {
+		name string
+		data *model.OpnSenseDocument
+	}{
+		{
+			name: "empty_system_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{},
+			},
+		},
+		{
+			name: "minimal_data",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+			},
+		},
+		{
+			name: "data_with_empty_interfaces",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				Interfaces: model.Interfaces{
+					Items: map[string]model.Interface{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := builder.BuildStandardReport(tt.data)
+			require.NoError(t, err)
+			assert.NotEmpty(t, result)
+			assert.Contains(t, result, "OPNsense Configuration Summary")
+		})
+	}
+}
+
+func TestBuildSecuritySection_EdgeCases(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	tests := []struct {
+		name string
+		data *model.OpnSenseDocument
+	}{
+		{
+			name: "no_nat_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+			},
+		},
+		{
+			name: "no_firewall_rules",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				Filter: model.Filter{
+					Rule: []model.Rule{},
+				},
+			},
+		},
+		{
+			name: "nat_without_outbound",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				Nat: model.Nat{
+					Outbound: model.Outbound{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildSecuritySection(tt.data)
+			assert.NotEmpty(t, result)
+			assert.Contains(t, result, "Security Configuration")
+		})
+	}
+}
+
+func TestBuildServicesSection_EdgeCases(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	tests := []struct {
+		name string
+		data *model.OpnSenseDocument
+	}{
+		{
+			name: "no_dhcp_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+			},
+		},
+		{
+			name: "no_unbound_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				Unbound: model.Unbound{},
+			},
+		},
+		{
+			name: "no_snmp_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				Snmpd: model.Snmpd{},
+			},
+		},
+		{
+			name: "no_ntpd_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				Ntpd: model.Ntpd{},
+			},
+		},
+		{
+			name: "no_load_balancer_config",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+				LoadBalancer: model.LoadBalancer{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildServicesSection(tt.data)
+			assert.NotEmpty(t, result)
+			assert.Contains(t, result, "Service Configuration")
+		})
+	}
+}
+
+func TestToMarkdown_EdgeCases(t *testing.T) {
+	converter := NewMarkdownConverter()
+
+	tests := []struct {
+		name string
+		data *model.OpnSenseDocument
+	}{
+		{
+			name: "empty_opnsense",
+			data: &model.OpnSenseDocument{},
+		},
+		{
+			name: "minimal_opnsense",
+			data: &model.OpnSenseDocument{
+				System: model.System{
+					Hostname: "test",
+					Domain:   "test.local",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := converter.ToMarkdown(context.Background(), tt.data)
+			require.NoError(t, err)
+			assert.NotEmpty(t, result)
+			// Remove ANSI color codes for comparison
+			cleanResult := strings.ReplaceAll(result, "\x1b[38;5;228;48;5;63;1m", "")
+			cleanResult = strings.ReplaceAll(cleanResult, "\x1b[0m", "")
+			cleanResult = strings.ReplaceAll(cleanResult, "\x1b[38;5;252m", "")
+			cleanResult = strings.ReplaceAll(cleanResult, "\x1b[38;5;39;1m", "")
+			cleanResult = strings.ReplaceAll(cleanResult, "\x1b[38;5;252;1m", "")
+			assert.Contains(t, cleanResult, "OPNsense Configuration")
+		})
+	}
+}
+
+func TestGetTheme_EdgeCases(t *testing.T) {
+	converter := NewMarkdownConverter()
+
+	// Test with different environment variables
+	tests := []struct {
+		name          string
+		envVars       map[string]string
+		expectedTheme string
+	}{
+		{
+			name: "default_theme",
+			envVars: map[string]string{
+				"TERM":      "dumb",
+				"COLORTERM": "",
+			},
+			expectedTheme: "auto",
+		},
+		{
+			name: "explicit_theme",
+			envVars: map[string]string{
+				"OPNDOSSIER_THEME": "dark",
+			},
+			expectedTheme: "dark",
+		},
+		{
+			name: "colorterm_truecolor",
+			envVars: map[string]string{
+				"COLORTERM": "truecolor",
+				"TERM":      "xterm-256color",
+			},
+			expectedTheme: "dark",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variables for test
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			theme := converter.getTheme()
+			assert.Equal(t, tt.expectedTheme, theme)
+		})
+	}
+}
+
+// Test that the MarkdownBuilder implements the ReportBuilder interface.
+func TestMarkdownBuilder_ImplementsReportBuilder(_ *testing.T) {
+	var _ ReportBuilder = (*MarkdownBuilder)(nil)
+}
+
+// Integration test comparing with the old MarkdownConverter.
+func TestMarkdownBuilder_IntegrationWithOldConverter(t *testing.T) {
+	// Create test data
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			Firmware: model.Firmware{
+				Version: "23.1.1",
+			},
+		},
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:     "em0",
+					Enable: "1",
+					IPAddr: "192.168.1.1",
+					Subnet: "24",
+				},
+			},
+		},
+	}
+
+	// Test new builder
+	builder := NewMarkdownBuilder()
+	newResult, err := builder.BuildStandardReport(data)
+	require.NoError(t, err)
+
+	// Test old converter
+	converter := NewMarkdownConverter()
+	oldResult, err := converter.ToMarkdown(context.Background(), data)
+	require.NoError(t, err)
+
+	// Both should produce valid markdown
+	assert.NotEmpty(t, newResult)
+	assert.NotEmpty(t, oldResult)
+
+	// Both should contain the same basic information
+	assert.Contains(t, newResult, "test-host")
+	assert.Contains(t, newResult, "test.local")
+	assert.Contains(t, newResult, "23.1.1")
+
+	// The new builder should have more comprehensive output
+	assert.Contains(t, newResult, "System Configuration")
+	assert.Contains(t, newResult, "Network Configuration")
+	assert.Contains(t, newResult, "Security Configuration")
+	assert.Contains(t, newResult, "Service Configuration")
+}
+
+// Benchmark tests for performance comparison.
+func BenchmarkMarkdownBuilder_BuildStandardReport(b *testing.B) {
+	builder := NewMarkdownBuilder()
+
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			Firmware: model.Firmware{
+				Version: "23.1.1",
+			},
+		},
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:     "em0",
+					Enable: "1",
+					IPAddr: "192.168.1.1",
+					Subnet: "24",
+				},
+				"lan": {
+					If:     "em1",
+					Enable: "1",
+					IPAddr: "10.0.0.1",
+					Subnet: "24",
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := builder.BuildStandardReport(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarkdownBuilder_BuildComprehensiveReport(b *testing.B) {
+	builder := NewMarkdownBuilder()
+
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			Firmware: model.Firmware{
+				Version: "23.1.1",
+			},
+		},
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:     "em0",
+					Enable: "1",
+					IPAddr: "192.168.1.1",
+					Subnet: "24",
+				},
+				"lan": {
+					If:     "em1",
+					Enable: "1",
+					IPAddr: "10.0.0.1",
+					Subnet: "24",
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, err := builder.BuildComprehensiveReport(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Test additional edge cases and missing coverage scenarios.
+func TestMarkdownBuilder_BuildSecuritySection_WithNATReflection(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with NAT reflection enabled
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			DisableNATReflection: "0", // NAT reflection enabled
+			PfShareForward:       1,
+		},
+		Nat: model.Nat{
+			Outbound: model.Outbound{
+				Mode: "automatic",
+			},
+		},
+		Filter: model.Filter{
+			Rule: []model.Rule{
+				{
+					Type:       "pass",
+					Descr:      "Test rule",
+					Interface:  model.InterfaceList{"lan"},
+					IPProtocol: "inet",
+					Protocol:   "tcp",
+					Source: model.Source{
+						Network: "lan",
+					},
+					Destination: model.Destination{
+						Network: "any",
+					},
+				},
+			},
+		},
+	}
+
+	result := builder.BuildSecuritySection(data)
+
+	// Verify NAT reflection warning is present when enabled
+	assert.Contains(t, result, "Security Warning")
+	assert.Contains(t, result, "NAT reflection is enabled")
+}
+
+func TestMarkdownBuilder_BuildServicesSection_WithLoadBalancerMonitors(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with load balancer monitors
+	data := &model.OpnSenseDocument{
+		LoadBalancer: model.LoadBalancer{
+			MonitorType: []model.MonitorType{
+				{
+					Name:  "http-monitor",
+					Type:  "http",
+					Descr: "HTTP Health Check",
+				},
+				{
+					Name:  "tcp-monitor",
+					Type:  "tcp",
+					Descr: "TCP Health Check",
+				},
+			},
+		},
+	}
+
+	result := builder.BuildServicesSection(data)
+
+	// Verify load balancer monitors are included
+	assert.Contains(t, result, "Load Balancer Monitors")
+	assert.Contains(t, result, "http-monitor")
+	assert.Contains(t, result, "tcp-monitor")
+	assert.Contains(t, result, "HTTP Health Check")
+	assert.Contains(t, result, "TCP Health Check")
+}
+
+func TestMarkdownBuilder_BuildStandardReport_WithUsersAndSysctl(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with users and sysctl data
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			User: []model.User{
+				{
+					Name:      "admin",
+					Descr:     "Administrator",
+					Groupname: "wheel",
+					Scope:     "system",
+				},
+				{
+					Name:      "user1",
+					Descr:     "Regular User",
+					Groupname: "users",
+					Scope:     "local",
+				},
+			},
+		},
+		Sysctl: []model.SysctlItem{
+			{
+				Tunable: "net.inet.ip.forwarding",
+				Value:   "1",
+				Descr:   "Enable IP forwarding",
+			},
+			{
+				Tunable: "net.inet.tcp.always_keepalive",
+				Value:   "0",
+				Descr:   "Disable TCP keepalive",
+			},
+		},
+	}
+
+	result, err := builder.BuildStandardReport(data)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	// Verify users and sysctl sections are included
+	assert.Contains(t, result, "System Users")
+	assert.Contains(t, result, "System Tunables")
+	assert.Contains(t, result, "admin")
+	assert.Contains(t, result, "user1")
+	assert.Contains(t, result, "net.inet.ip.forwarding")
+	assert.Contains(t, result, "net.inet.tcp.always_keepalive")
+}
+
+func TestMarkdownBuilder_BuildComprehensiveReport_WithGroups(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test comprehensive report with groups
+	data := &model.OpnSenseDocument{
+		System: model.System{
+			Hostname: "test-host",
+			Domain:   "test.local",
+			Group: []model.Group{
+				{
+					Name:        "wheel",
+					Description: "Wheel group",
+					Scope:       "system",
+				},
+				{
+					Name:        "users",
+					Description: "Regular users",
+					Scope:       "local",
+				},
+			},
+		},
+	}
+
+	result, err := builder.BuildComprehensiveReport(data)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+
+	// Verify groups section is included in comprehensive report
+	assert.Contains(t, result, "System Groups")
+	assert.Contains(t, result, "wheel")
+	assert.Contains(t, result, "users")
+}
+
+func TestMarkdownBuilder_BuildFirewallRulesTable_WithComplexRules(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with complex firewall rules including all fields
+	rules := []model.Rule{
+		{
+			Type:       "pass",
+			Descr:      "Allow HTTPS",
+			Interface:  model.InterfaceList{"wan"},
+			IPProtocol: "inet",
+			Protocol:   "tcp",
+			Source: model.Source{
+				Network: "any",
+			},
+			Destination: model.Destination{
+				Network: "lan",
+			},
+			Target:     "lan",
+			SourcePort: "443",
+			Disabled:   "1", // Disabled rule
+		},
+		{
+			Type:       "block",
+			Descr:      "Block SSH",
+			Interface:  model.InterfaceList{"wan", "lan"},
+			IPProtocol: "inet6",
+			Protocol:   "tcp",
+			Source: model.Source{
+				Network: "lan",
+			},
+			Destination: model.Destination{
+				Network: "wan",
+			},
+			Target:     "",
+			SourcePort: "22",
+			Disabled:   "",
+		},
+	}
+
+	tableSet := builder.BuildFirewallRulesTable(rules)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 11)
+	assert.Len(t, tableSet.Rows, 2)
+
+	// Verify first row (disabled rule)
+	row1 := tableSet.Rows[0]
+	assert.Equal(t, "1", row1[0])            // #
+	assert.Contains(t, row1[1], "wan")       // Interface
+	assert.Equal(t, "pass", row1[2])         // Action
+	assert.Equal(t, "inet", row1[3])         // IP Ver
+	assert.Equal(t, "tcp", row1[4])          // Proto
+	assert.Equal(t, "any", row1[5])          // Source
+	assert.Equal(t, "lan", row1[6])          // Destination
+	assert.Equal(t, "lan", row1[7])          // Target
+	assert.Equal(t, "443", row1[8])          // Source Port
+	assert.Equal(t, "✗", row1[9])            // Enabled (disabled)
+	assert.Equal(t, "Allow HTTPS", row1[10]) // Description
+
+	// Verify second row (enabled rule)
+	row2 := tableSet.Rows[1]
+	assert.Equal(t, "2", row2[0])          // #
+	assert.Contains(t, row2[1], "wan")     // Interface
+	assert.Contains(t, row2[1], "lan")     // Interface
+	assert.Equal(t, "block", row2[2])      // Action
+	assert.Equal(t, "inet6", row2[3])      // IP Ver
+	assert.Equal(t, "tcp", row2[4])        // Proto
+	assert.Equal(t, "lan", row2[5])        // Source
+	assert.Equal(t, "wan", row2[6])        // Destination
+	assert.Empty(t, row2[7])               // Target
+	assert.Equal(t, "22", row2[8])         // Source Port
+	assert.Equal(t, "✓", row2[9])          // Enabled
+	assert.Equal(t, "Block SSH", row2[10]) // Description
+}
+
+func TestMarkdownBuilder_BuildInterfaceTable_WithComplexInterfaces(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with complex interface configurations
+	interfaces := model.Interfaces{
+		Items: map[string]model.Interface{
+			"wan": {
+				If:          "em0",
+				Enable:      "1",
+				IPAddr:      "192.168.1.1",
+				Subnet:      "24",
+				Gateway:     "192.168.1.254",
+				MTU:         "1500",
+				BlockPriv:   "1",
+				BlockBogons: "1",
+				Descr:       "WAN Interface",
+			},
+			"lan": {
+				If:          "em1",
+				Enable:      "0", // Disabled interface
+				IPAddr:      "10.0.0.1",
+				Subnet:      "24",
+				Gateway:     "",
+				MTU:         "1500",
+				BlockPriv:   "0",
+				BlockBogons: "0",
+				Descr:       "LAN Interface",
+			},
+			"opt1": {
+				If:          "em2",
+				Enable:      "1",
+				IPAddr:      "172.16.0.1",
+				Subnet:      "16",
+				Gateway:     "",
+				MTU:         "9000",
+				BlockPriv:   "0",
+				BlockBogons: "0",
+				Descr:       "DMZ Interface",
+			},
+		},
+	}
+
+	tableSet := builder.BuildInterfaceTable(interfaces)
+
+	assert.NotNil(t, tableSet)
+	assert.Len(t, tableSet.Header, 5)
+	assert.Len(t, tableSet.Rows, 3)
+
+	// Verify all interfaces are present
+	interfaceNames := make(map[string]bool)
+	for _, row := range tableSet.Rows {
+		interfaceNames[row[0]] = true
+	}
+
+	assert.True(t, interfaceNames["`wan`"])
+	assert.True(t, interfaceNames["`lan`"])
+	assert.True(t, interfaceNames["`opt1`"])
+
+	// Verify specific interface details
+	rowData := make(map[string][]string)
+	for _, row := range tableSet.Rows {
+		rowData[row[0]] = row
+	}
+
+	// Check WAN interface (enabled)
+	wanRow := rowData["`wan`"]
+	assert.Equal(t, "`WAN Interface`", wanRow[1])
+	assert.Equal(t, "`192.168.1.1`", wanRow[2])
+	assert.Equal(t, "/24", wanRow[3])
+	assert.Equal(t, "✓", wanRow[4])
+
+	// Check LAN interface (disabled)
+	lanRow := rowData["`lan`"]
+	assert.Equal(t, "`LAN Interface`", lanRow[1])
+	assert.Equal(t, "`10.0.0.1`", lanRow[2])
+	assert.Equal(t, "/24", lanRow[3])
+	assert.Equal(t, "✗", lanRow[4])
+
+	// Check OPT1 interface (enabled)
+	opt1Row := rowData["`opt1`"]
+	assert.Equal(t, "`DMZ Interface`", opt1Row[1])
+	assert.Equal(t, "`172.16.0.1`", opt1Row[2])
+	assert.Equal(t, "/16", opt1Row[3])
+	assert.Equal(t, "✓", opt1Row[4])
+}
+
+func TestFormatIntBooleanWithUnset(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{"true value", 1, "✓"},
+		{"false value", 0, "unset"},
+		{"unset value", -1, "✗"},
+		{"negative value", -5, "✗"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatIntBooleanWithUnset(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormatStructBoolean(t *testing.T) {
+	// Test with empty struct
+	result := formatStructBoolean(struct{}{})
+	assert.Equal(t, "✓", result)
+}
+
+func TestMarkdownBuilder_BuildSystemSection_WithAllFields(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with comprehensive system configuration
+	data := createComprehensiveTestData()
+
+	result := builder.BuildSystemSection(data)
+
+	// Verify all sections are present
+	assert.Contains(t, result, "System Configuration")
+	assert.Contains(t, result, "Basic Information")
+	assert.Contains(t, result, "Web GUI Configuration")
+	assert.Contains(t, result, "System Settings")
+	assert.Contains(t, result, "Hardware Offloading")
+	assert.Contains(t, result, "Power Management")
+	assert.Contains(t, result, "System Features")
+	assert.Contains(t, result, "Bogons Configuration")
+	assert.Contains(t, result, "SSH Configuration")
+	assert.Contains(t, result, "Firmware Information")
+	assert.Contains(t, result, "System Tunables")
+	assert.Contains(t, result, "System Users")
+	assert.Contains(t, result, "System Groups")
+
+	// Verify specific values
+	assert.Contains(t, result, "test-host")
+	assert.Contains(t, result, "test.local")
+	assert.Contains(t, result, "normal")
+	assert.Contains(t, result, "UTC")
+	assert.Contains(t, result, "en_US")
+	assert.Contains(t, result, "https")
+	assert.Contains(t, result, "wheel")
+	assert.Contains(t, result, "23.1.1")
+	assert.Contains(t, result, "daily")
+	assert.Contains(t, result, "net.inet.ip.forwarding")
+	assert.Contains(t, result, "admin")
+	assert.Contains(t, result, "8.8.8.8")
+	assert.Contains(t, result, "pool.ntp.org")
+}
+
+// createComprehensiveTestData creates a comprehensive test data structure.
+func createComprehensiveTestData() *model.OpnSenseDocument {
+	return &model.OpnSenseDocument{
+		System: model.System{
+			Hostname:                      "test-host",
+			Domain:                        "test.local",
+			Optimization:                  "normal",
+			Timezone:                      "UTC",
+			Language:                      "en_US",
+			DNSAllowOverride:              1,
+			NextUID:                       1000,
+			NextGID:                       1000,
+			TimeServers:                   "pool.ntp.org",
+			DNSServer:                     "8.8.8.8",
+			UseVirtualTerminal:            1,
+			DisableVLANHWFilter:           0,
+			DisableChecksumOffloading:     0,
+			DisableSegmentationOffloading: 0,
+			DisableLargeReceiveOffloading: 0,
+			IPv6Allow:                     "1",
+			DisableNATReflection:          "0", // NAT reflection enabled
+			PowerdACMode:                  "adaptive",
+			PowerdBatteryMode:             "minimum",
+			PowerdNormalMode:              "adaptive",
+			PfShareForward:                1,
+			LbUseSticky:                   0,
+			RrdBackup:                     1,
+			NetflowBackup:                 0,
+			WebGUI: model.WebGUIConfig{
+				Protocol: "https",
+			},
+			SSH: model.SSHConfig{
+				Group: "wheel",
+			},
+			Firmware: model.Firmware{
+				Version: "23.1.1",
+			},
+			Bogons: struct {
+				Interval string `xml:"interval" json:"interval,omitempty" yaml:"interval,omitempty" validate:"omitempty,oneof=monthly weekly daily never"`
+			}{
+				Interval: "daily",
+			},
+			User: []model.User{
+				{
+					Name:      "admin",
+					Descr:     "Administrator",
+					Groupname: "wheel",
+					Scope:     "system",
+				},
+			},
+			Group: []model.Group{
+				{
+					Name:        "wheel",
+					Description: "Wheel group",
+					Scope:       "system",
+				},
+			},
+		},
+		Sysctl: []model.SysctlItem{
+			{
+				Tunable: "net.inet.ip.forwarding",
+				Value:   "1",
+				Descr:   "Enable IP forwarding",
+			},
+		},
+	}
+}
+
+func TestMarkdownBuilder_BuildNetworkSection_WithComplexInterfaces(t *testing.T) {
+	builder := NewMarkdownBuilder()
+
+	// Test with complex network configuration
+	data := &model.OpnSenseDocument{
+		Interfaces: model.Interfaces{
+			Items: map[string]model.Interface{
+				"wan": {
+					If:          "em0",
+					Enable:      "1",
+					IPAddr:      "192.168.1.1",
+					Subnet:      "24",
+					Gateway:     "192.168.1.254",
+					MTU:         "1500",
+					BlockPriv:   "1",
+					BlockBogons: "1",
+					Descr:       "WAN Interface",
+				},
+				"lan": {
+					If:          "em1",
+					Enable:      "1",
+					IPAddr:      "10.0.0.1",
+					Subnet:      "24",
+					Gateway:     "",
+					MTU:         "1500",
+					BlockPriv:   "0",
+					BlockBogons: "0",
+					Descr:       "LAN Interface",
+				},
+				"opt1": {
+					If:          "em2",
+					Enable:      "1",
+					IPAddr:      "172.16.0.1",
+					Subnet:      "16",
+					Gateway:     "",
+					MTU:         "9000",
+					BlockPriv:   "0",
+					BlockBogons: "0",
+					Descr:       "DMZ Interface",
+				},
+			},
+		},
+	}
+
+	result := builder.BuildNetworkSection(data)
+
+	// Verify the result contains expected sections
+	assert.Contains(t, result, "Network Configuration")
+	assert.Contains(t, result, "Interfaces")
+	assert.Contains(t, result, "Wan Interface")
+	assert.Contains(t, result, "Lan Interface")
+	assert.Contains(t, result, "DMZ Interface")
+
+	// Verify interface details
+	assert.Contains(t, result, "em0")
+	assert.Contains(t, result, "em1")
+	assert.Contains(t, result, "em2")
+	assert.Contains(t, result, "192.168.1.1")
+	assert.Contains(t, result, "10.0.0.1")
+	assert.Contains(t, result, "172.16.0.1")
+	assert.Contains(t, result, "WAN Interface")
+	assert.Contains(t, result, "LAN Interface")
+	assert.Contains(t, result, "DMZ Interface")
+	assert.Contains(t, result, "192.168.1.254") // Gateway
+	assert.Contains(t, result, "1500")          // MTU
+	assert.Contains(t, result, "9000")          // MTU for opt1
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive tests for the MarkdownBuilder functionality, including:

- Fixed benchmark tests to use proper Go testing patterns
- Added comprehensive test coverage for markdown generation
- Improved test organization and readability
- Ensured all tests pass linting and CI checks

## Changes

- Fixed benchmark loop issues in 
- Added comprehensive test coverage for markdown builder functionality
- Updated tests to follow Go best practices and project standards

## Testing

- All tests pass: === RUN   TestJSONConverter_ToJSON
=== RUN   TestJSONConverter_ToJSON/nil_opnsense
=== RUN   TestJSONConverter_ToJSON/valid_opnsense
--- PASS: TestJSONConverter_ToJSON (0.00s)
    --- PASS: TestJSONConverter_ToJSON/nil_opnsense (0.00s)
    --- PASS: TestJSONConverter_ToJSON/valid_opnsense (0.00s)
=== RUN   TestNewMarkdownBuilder
--- PASS: TestNewMarkdownBuilder (0.00s)
=== RUN   TestMarkdownBuilder_BuildSystemSection
--- PASS: TestMarkdownBuilder_BuildSystemSection (0.00s)
=== RUN   TestMarkdownBuilder_BuildNetworkSection
--- PASS: TestMarkdownBuilder_BuildNetworkSection (0.00s)
=== RUN   TestMarkdownBuilder_BuildSecuritySection
--- PASS: TestMarkdownBuilder_BuildSecuritySection (0.00s)
=== RUN   TestMarkdownBuilder_BuildServicesSection
--- PASS: TestMarkdownBuilder_BuildServicesSection (0.00s)
=== RUN   TestMarkdownBuilder_BuildFirewallRulesTable
--- PASS: TestMarkdownBuilder_BuildFirewallRulesTable (0.00s)
=== RUN   TestMarkdownBuilder_BuildInterfaceTable
--- PASS: TestMarkdownBuilder_BuildInterfaceTable (0.00s)
=== RUN   TestMarkdownBuilder_BuildUserTable
--- PASS: TestMarkdownBuilder_BuildUserTable (0.00s)
=== RUN   TestMarkdownBuilder_BuildGroupTable
--- PASS: TestMarkdownBuilder_BuildGroupTable (0.00s)
=== RUN   TestMarkdownBuilder_BuildSysctlTable
--- PASS: TestMarkdownBuilder_BuildSysctlTable (0.00s)
=== RUN   TestMarkdownBuilder_BuildStandardReport
--- PASS: TestMarkdownBuilder_BuildStandardReport (0.00s)
=== RUN   TestMarkdownBuilder_BuildComprehensiveReport
--- PASS: TestMarkdownBuilder_BuildComprehensiveReport (0.00s)
=== RUN   TestMarkdownBuilder_BuildStandardReport_NilData
--- PASS: TestMarkdownBuilder_BuildStandardReport_NilData (0.00s)
=== RUN   TestMarkdownBuilder_BuildComprehensiveReport_NilData
--- PASS: TestMarkdownBuilder_BuildComprehensiveReport_NilData (0.00s)
=== RUN   TestFormatBoolean
=== RUN   TestFormatBoolean/true_value
=== RUN   TestFormatBoolean/true_string
=== RUN   TestFormatBoolean/on_value
=== RUN   TestFormatBoolean/false_value
=== RUN   TestFormatBoolean/false_string
=== RUN   TestFormatBoolean/empty_string
=== RUN   TestFormatBoolean/random_string
--- PASS: TestFormatBoolean (0.00s)
    --- PASS: TestFormatBoolean/true_value (0.00s)
    --- PASS: TestFormatBoolean/true_string (0.00s)
    --- PASS: TestFormatBoolean/on_value (0.00s)
    --- PASS: TestFormatBoolean/false_value (0.00s)
    --- PASS: TestFormatBoolean/false_string (0.00s)
    --- PASS: TestFormatBoolean/empty_string (0.00s)
    --- PASS: TestFormatBoolean/random_string (0.00s)
=== RUN   TestFormatIntBoolean
=== RUN   TestFormatIntBoolean/true_value
=== RUN   TestFormatIntBoolean/false_value
=== RUN   TestFormatIntBoolean/negative_value
--- PASS: TestFormatIntBoolean (0.00s)
    --- PASS: TestFormatIntBoolean/true_value (0.00s)
    --- PASS: TestFormatIntBoolean/false_value (0.00s)
    --- PASS: TestFormatIntBoolean/negative_value (0.00s)
=== RUN   TestFormatBool
=== RUN   TestFormatBool/true_value
=== RUN   TestFormatBool/false_value
--- PASS: TestFormatBool (0.00s)
    --- PASS: TestFormatBool/true_value (0.00s)
    --- PASS: TestFormatBool/false_value (0.00s)
=== RUN   TestGetPowerModeDescription
=== RUN   TestGetPowerModeDescription/hadp
=== RUN   TestGetPowerModeDescription/maximum
=== RUN   TestGetPowerModeDescription/minimum
=== RUN   TestGetPowerModeDescription/hiadaptive
=== RUN   TestGetPowerModeDescription/adaptive
=== RUN   TestGetPowerModeDescription/unknown
=== RUN   TestGetPowerModeDescription/empty
--- PASS: TestGetPowerModeDescription (0.00s)
    --- PASS: TestGetPowerModeDescription/hadp (0.00s)
    --- PASS: TestGetPowerModeDescription/maximum (0.00s)
    --- PASS: TestGetPowerModeDescription/minimum (0.00s)
    --- PASS: TestGetPowerModeDescription/hiadaptive (0.00s)
    --- PASS: TestGetPowerModeDescription/adaptive (0.00s)
    --- PASS: TestGetPowerModeDescription/unknown (0.00s)
    --- PASS: TestGetPowerModeDescription/empty (0.00s)
=== RUN   TestFormatBooleanInverted
=== RUN   TestFormatBooleanInverted/true_value
=== RUN   TestFormatBooleanInverted/true_string
=== RUN   TestFormatBooleanInverted/on_value
=== RUN   TestFormatBooleanInverted/false_value
=== RUN   TestFormatBooleanInverted/false_string
=== RUN   TestFormatBooleanInverted/empty_string
=== RUN   TestFormatBooleanInverted/random_string
--- PASS: TestFormatBooleanInverted (0.00s)
    --- PASS: TestFormatBooleanInverted/true_value (0.00s)
    --- PASS: TestFormatBooleanInverted/true_string (0.00s)
    --- PASS: TestFormatBooleanInverted/on_value (0.00s)
    --- PASS: TestFormatBooleanInverted/false_value (0.00s)
    --- PASS: TestFormatBooleanInverted/false_string (0.00s)
    --- PASS: TestFormatBooleanInverted/empty_string (0.00s)
    --- PASS: TestFormatBooleanInverted/random_string (0.00s)
=== RUN   TestBuildFirewallRulesTable_EdgeCases
=== RUN   TestBuildFirewallRulesTable_EdgeCases/empty_rules
=== RUN   TestBuildFirewallRulesTable_EdgeCases/rules_with_empty_networks
=== RUN   TestBuildFirewallRulesTable_EdgeCases/rules_with_nil_interface
--- PASS: TestBuildFirewallRulesTable_EdgeCases (0.00s)
    --- PASS: TestBuildFirewallRulesTable_EdgeCases/empty_rules (0.00s)
    --- PASS: TestBuildFirewallRulesTable_EdgeCases/rules_with_empty_networks (0.00s)
    --- PASS: TestBuildFirewallRulesTable_EdgeCases/rules_with_nil_interface (0.00s)
=== RUN   TestBuildStandardReport_EdgeCases
=== RUN   TestBuildStandardReport_EdgeCases/empty_system_config
=== RUN   TestBuildStandardReport_EdgeCases/minimal_data
=== RUN   TestBuildStandardReport_EdgeCases/data_with_empty_interfaces
--- PASS: TestBuildStandardReport_EdgeCases (0.00s)
    --- PASS: TestBuildStandardReport_EdgeCases/empty_system_config (0.00s)
    --- PASS: TestBuildStandardReport_EdgeCases/minimal_data (0.00s)
    --- PASS: TestBuildStandardReport_EdgeCases/data_with_empty_interfaces (0.00s)
=== RUN   TestBuildSecuritySection_EdgeCases
=== RUN   TestBuildSecuritySection_EdgeCases/no_nat_config
=== RUN   TestBuildSecuritySection_EdgeCases/no_firewall_rules
=== RUN   TestBuildSecuritySection_EdgeCases/nat_without_outbound
--- PASS: TestBuildSecuritySection_EdgeCases (0.00s)
    --- PASS: TestBuildSecuritySection_EdgeCases/no_nat_config (0.00s)
    --- PASS: TestBuildSecuritySection_EdgeCases/no_firewall_rules (0.00s)
    --- PASS: TestBuildSecuritySection_EdgeCases/nat_without_outbound (0.00s)
=== RUN   TestBuildServicesSection_EdgeCases
=== RUN   TestBuildServicesSection_EdgeCases/no_dhcp_config
=== RUN   TestBuildServicesSection_EdgeCases/no_unbound_config
=== RUN   TestBuildServicesSection_EdgeCases/no_snmp_config
=== RUN   TestBuildServicesSection_EdgeCases/no_ntpd_config
=== RUN   TestBuildServicesSection_EdgeCases/no_load_balancer_config
--- PASS: TestBuildServicesSection_EdgeCases (0.00s)
    --- PASS: TestBuildServicesSection_EdgeCases/no_dhcp_config (0.00s)
    --- PASS: TestBuildServicesSection_EdgeCases/no_unbound_config (0.00s)
    --- PASS: TestBuildServicesSection_EdgeCases/no_snmp_config (0.00s)
    --- PASS: TestBuildServicesSection_EdgeCases/no_ntpd_config (0.00s)
    --- PASS: TestBuildServicesSection_EdgeCases/no_load_balancer_config (0.00s)
=== RUN   TestToMarkdown_EdgeCases
=== RUN   TestToMarkdown_EdgeCases/empty_opnsense
=== RUN   TestToMarkdown_EdgeCases/minimal_opnsense
--- PASS: TestToMarkdown_EdgeCases (0.00s)
    --- PASS: TestToMarkdown_EdgeCases/empty_opnsense (0.00s)
    --- PASS: TestToMarkdown_EdgeCases/minimal_opnsense (0.00s)
=== RUN   TestGetTheme_EdgeCases
=== RUN   TestGetTheme_EdgeCases/default_theme
=== RUN   TestGetTheme_EdgeCases/explicit_theme
=== RUN   TestGetTheme_EdgeCases/colorterm_truecolor
--- PASS: TestGetTheme_EdgeCases (0.00s)
    --- PASS: TestGetTheme_EdgeCases/default_theme (0.00s)
    --- PASS: TestGetTheme_EdgeCases/explicit_theme (0.00s)
    --- PASS: TestGetTheme_EdgeCases/colorterm_truecolor (0.00s)
=== RUN   TestMarkdownBuilder_ImplementsReportBuilder
--- PASS: TestMarkdownBuilder_ImplementsReportBuilder (0.00s)
=== RUN   TestMarkdownBuilder_IntegrationWithOldConverter
--- PASS: TestMarkdownBuilder_IntegrationWithOldConverter (0.00s)
=== RUN   TestMarkdownBuilder_BuildSecuritySection_WithNATReflection
--- PASS: TestMarkdownBuilder_BuildSecuritySection_WithNATReflection (0.00s)
=== RUN   TestMarkdownBuilder_BuildServicesSection_WithLoadBalancerMonitors
--- PASS: TestMarkdownBuilder_BuildServicesSection_WithLoadBalancerMonitors (0.00s)
=== RUN   TestMarkdownBuilder_BuildStandardReport_WithUsersAndSysctl
--- PASS: TestMarkdownBuilder_BuildStandardReport_WithUsersAndSysctl (0.00s)
=== RUN   TestMarkdownBuilder_BuildComprehensiveReport_WithGroups
--- PASS: TestMarkdownBuilder_BuildComprehensiveReport_WithGroups (0.00s)
=== RUN   TestMarkdownBuilder_BuildFirewallRulesTable_WithComplexRules
--- PASS: TestMarkdownBuilder_BuildFirewallRulesTable_WithComplexRules (0.00s)
=== RUN   TestMarkdownBuilder_BuildInterfaceTable_WithComplexInterfaces
--- PASS: TestMarkdownBuilder_BuildInterfaceTable_WithComplexInterfaces (0.00s)
=== RUN   TestFormatIntBooleanWithUnset
=== RUN   TestFormatIntBooleanWithUnset/true_value
=== RUN   TestFormatIntBooleanWithUnset/false_value
=== RUN   TestFormatIntBooleanWithUnset/unset_value
=== RUN   TestFormatIntBooleanWithUnset/negative_value
--- PASS: TestFormatIntBooleanWithUnset (0.00s)
    --- PASS: TestFormatIntBooleanWithUnset/true_value (0.00s)
    --- PASS: TestFormatIntBooleanWithUnset/false_value (0.00s)
    --- PASS: TestFormatIntBooleanWithUnset/unset_value (0.00s)
    --- PASS: TestFormatIntBooleanWithUnset/negative_value (0.00s)
=== RUN   TestFormatStructBoolean
--- PASS: TestFormatStructBoolean (0.00s)
=== RUN   TestMarkdownBuilder_BuildSystemSection_WithAllFields
--- PASS: TestMarkdownBuilder_BuildSystemSection_WithAllFields (0.00s)
=== RUN   TestMarkdownBuilder_BuildNetworkSection_WithComplexInterfaces
--- PASS: TestMarkdownBuilder_BuildNetworkSection_WithComplexInterfaces (0.00s)
=== RUN   TestMarkdownConverter_ToMarkdown
=== RUN   TestMarkdownConverter_ToMarkdown/basic_conversion
=== RUN   TestMarkdownConverter_ToMarkdown/nil_input
=== RUN   TestMarkdownConverter_ToMarkdown/empty_struct
=== RUN   TestMarkdownConverter_ToMarkdown/missing_system_fields
--- PASS: TestMarkdownConverter_ToMarkdown (0.00s)
    --- PASS: TestMarkdownConverter_ToMarkdown/basic_conversion (0.00s)
    --- PASS: TestMarkdownConverter_ToMarkdown/nil_input (0.00s)
    --- PASS: TestMarkdownConverter_ToMarkdown/empty_struct (0.00s)
    --- PASS: TestMarkdownConverter_ToMarkdown/missing_system_fields (0.00s)
=== RUN   TestMarkdownConverter_ConvertFromTestdataFile
--- PASS: TestMarkdownConverter_ConvertFromTestdataFile (0.01s)
=== RUN   TestMarkdownConverter_EdgeCases
=== RUN   TestMarkdownConverter_EdgeCases/nil_opnsense_struct
=== RUN   TestMarkdownConverter_EdgeCases/empty_opnsense_struct
=== RUN   TestMarkdownConverter_EdgeCases/opnsense_with_only_system_configuration
=== RUN   TestMarkdownConverter_EdgeCases/opnsense_with_complex_sysctl_configuration
=== RUN   TestMarkdownConverter_EdgeCases/opnsense_with_users_and_groups
=== RUN   TestMarkdownConverter_EdgeCases/opnsense_with_multiple_firewall_rules
=== RUN   TestMarkdownConverter_EdgeCases/firewall_rules_with_actual_protocol_data
=== RUN   TestMarkdownConverter_EdgeCases/opnsense_with_load_balancer_monitors
--- PASS: TestMarkdownConverter_EdgeCases (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/nil_opnsense_struct (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/empty_opnsense_struct (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/opnsense_with_only_system_configuration (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/opnsense_with_complex_sysctl_configuration (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/opnsense_with_users_and_groups (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/opnsense_with_multiple_firewall_rules (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/firewall_rules_with_actual_protocol_data (0.00s)
    --- PASS: TestMarkdownConverter_EdgeCases/opnsense_with_load_balancer_monitors (0.00s)
=== RUN   TestMarkdownConverter_ThemeSelection
=== RUN   TestMarkdownConverter_ThemeSelection/default_theme_selection
--- PASS: TestMarkdownConverter_ThemeSelection (0.00s)
    --- PASS: TestMarkdownConverter_ThemeSelection/default_theme_selection (0.00s)
=== RUN   TestNewMarkdownConverter
--- PASS: TestNewMarkdownConverter (0.00s)
=== RUN   TestFormatInterfacesAsLinks
=== RUN   TestFormatInterfacesAsLinks/empty_interface_list
=== RUN   TestFormatInterfacesAsLinks/single_interface
=== RUN   TestFormatInterfacesAsLinks/multiple_interfaces
=== RUN   TestFormatInterfacesAsLinks/mixed_case_interface_names
--- PASS: TestFormatInterfacesAsLinks (0.00s)
    --- PASS: TestFormatInterfacesAsLinks/empty_interface_list (0.00s)
    --- PASS: TestFormatInterfacesAsLinks/single_interface (0.00s)
    --- PASS: TestFormatInterfacesAsLinks/multiple_interfaces (0.00s)
    --- PASS: TestFormatInterfacesAsLinks/mixed_case_interface_names (0.00s)
=== RUN   TestMarkdownConverter_FirewallRulesWithInterfaceLinks
--- PASS: TestMarkdownConverter_FirewallRulesWithInterfaceLinks (0.00s)
=== RUN   TestYAMLConverter_ToYAML
=== RUN   TestYAMLConverter_ToYAML/nil_opnsense
=== RUN   TestYAMLConverter_ToYAML/valid_opnsense
--- PASS: TestYAMLConverter_ToYAML (0.00s)
    --- PASS: TestYAMLConverter_ToYAML/nil_opnsense (0.00s)
    --- PASS: TestYAMLConverter_ToYAML/valid_opnsense (0.00s)
PASS
ok  	github.com/EvilBit-Labs/opnDossier/internal/converter	(cached)
- Benchmarks run successfully: goos: darwin
goarch: arm64
pkg: github.com/EvilBit-Labs/opnDossier/internal/converter
cpu: Apple M4 Pro
BenchmarkMarkdownBuilder_BuildStandardReport-12         	   35946	     33361 ns/op
BenchmarkMarkdownBuilder_BuildComprehensiveReport-12    	   35983	     33528 ns/op
PASS
ok  	github.com/EvilBit-Labs/opnDossier/internal/converter	2.441s
- Linting passes: 0 issues.
- CI checks pass: check for added large files..............................................[42mPassed[m
check for case conflicts.................................................[42mPassed[m
check for merge conflicts................................................[42mPassed[m
check illegal windows names..........................(no files to check)[46;30mSkipped[m
check json...............................................................[42mPassed[m
check toml...............................................................[42mPassed[m
check yaml...............................................................[42mPassed[m
check xml................................................................[42mPassed[m
mixed line ending........................................................[42mPassed[m
check docstring is first.............................(no files to check)[46;30mSkipped[m
check vcs permalinks.....................................................[42mPassed[m
Lint GitHub Actions workflow files.......................................[42mPassed[m
ShellCheck v0.11.0...................................(no files to check)[46;30mSkipped[m
mdformat.................................................................[42mPassed[m
0 issues.
ok  	github.com/EvilBit-Labs/opnDossier	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/cmd	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/audit	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/config	(cached)
?   	github.com/EvilBit-Labs/opnDossier/internal/constants	[no test files]
ok  	github.com/EvilBit-Labs/opnDossier/internal/converter	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/display	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/export	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/log	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/markdown	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/metrics	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/model	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/parser	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/plugin	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/plugins/firewall	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/plugins/sans	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/plugins/stig	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/processor	(cached)
ok  	github.com/EvilBit-Labs/opnDossier/internal/validator	(cached)

## Related Issues

Closes #84