### PR TITLE
fix(sanitize): refuse to write output over the input file

### DIFF
--- a/cmd/sanitize.go
+++ b/cmd/sanitize.go
@@ -428,14 +428,40 @@ func pathsResolveToSameFile(pathA, pathB string) (bool, error) {
 	return os.SameFile(infoA, infoB), nil
 }
 
-// writeSanitizeArtifact creates path, writes content, and flushes it to disk.
+// sanitizeArtifactPermissions is the mode both sanitize outputs are created
+// with. It matches export.DefaultFilePermissions, which every other command in
+// this tool already writes with.
+//
+// os.Create would use 0666 masked by umask, so typically 0644. That is the
+// wrong default here. The --mapping file is the reverse-lookup table: it holds
+// every original hostname, address, username, and email in cleartext next to
+// its pseudonym, and it is written into whatever directory the operator happens
+// to be working in. The sanitized configuration itself still carries real
+// topology in moderate and minimal modes.
+const sanitizeArtifactPermissions = 0o600
+
+// writeSanitizeArtifact creates path with owner-only permissions, writes
+// content, and flushes it to disk.
+//
 // Close failures are returned rather than logged: a failed close can mean the
 // bytes never reached the filesystem, and this command exists to produce files
 // an operator is about to share.
+//
+// The explicit Chmod is not redundant. The mode passed to OpenFile applies to
+// newly created files only, so re-running sanitize over a mapping file that an
+// earlier version left at 0644 would otherwise keep it world-readable, which is
+// exactly the case worth fixing. Chmod makes the resulting permissions the same
+// whether or not the target already existed.
 func writeSanitizeArtifact(path string, content []byte) error {
-	file, err := os.Create(path)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sanitizeArtifactPermissions)
 	if err != nil {
 		return fmt.Errorf("create: %w", err)
+	}
+
+	if err := file.Chmod(sanitizeArtifactPermissions); err != nil {
+		_ = file.Close()
+
+		return fmt.Errorf("set permissions: %w", err)
 	}
 
 	if _, err := file.Write(content); err != nil {

--- a/cmd/sanitize.go
+++ b/cmd/sanitize.go
@@ -3,9 +3,11 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +39,10 @@ const (
 var (
 	// ErrInvalidSanitizeMode is returned when an invalid sanitization mode is specified.
 	ErrInvalidSanitizeMode = errors.New("invalid sanitize mode")
+
+	// ErrSanitizePathCollision is returned when the input file, --output, and
+	// --mapping paths do not all refer to distinct files.
+	ErrSanitizePathCollision = errors.New("sanitize path collision")
 )
 
 // opndossier sanitize config.xml --mode aggressive --output sanitized.xml --mapping map.json --force.
@@ -113,8 +119,9 @@ var sanitizeCmd = &cobra.Command{ //nolint:gochecknoglobals // Cobra command
 	Long: `The 'sanitize' command redacts sensitive information from OPNsense configuration
 files, making them safe to share for troubleshooting, documentation, or public
 reporting without exposing credentials, IP addresses, or other sensitive data.
-Unlike --redact on other commands (which only affects the rendered output),
-sanitize rewrites the source config.xml itself.
+Unlike --redact on other commands (which only affects the rendered report),
+sanitize produces a redacted copy of the config.xml itself. The input file is
+never modified.
 
 SANITIZATION MODES:
   Choose the mode with --mode/-m based on your sharing context:
@@ -196,6 +203,14 @@ RELATED:
 			}
 		}
 
+		// Reject a run whose input, --output, and --mapping do not all refer to
+		// distinct files. This must happen before anything is opened for
+		// writing: os.Create truncates, so an --output aimed at the input would
+		// empty the configuration before the sanitizer ever reads it.
+		if err := validateSanitizePaths(cleanPath, sanitizeOutputFile, sanitizeMappingFile); err != nil {
+			return err
+		}
+
 		// Open input file
 		file, err := os.Open(cleanPath)
 		if err != nil {
@@ -211,12 +226,11 @@ RELATED:
 		ctxLogger.Debug("Creating sanitizer", "mode", sanitizeMode)
 		s := sanitizer.NewSanitizer(sanitizer.Mode(sanitizeMode))
 
-		// Determine output destination
-		var outputWriter *os.File
+		// Resolve the output destination and settle overwrite protection before
+		// any work happens, so declining the prompt costs nothing.
 		actualOutputFile := ""
 
 		if sanitizeOutputFile != "" {
-			// Handle overwrite protection
 			actualOutputFile, err = determineSanitizeOutputPath(sanitizeOutputFile, sanitizeForce)
 			if err != nil {
 				if errors.Is(err, ErrOperationCancelled) {
@@ -226,18 +240,7 @@ RELATED:
 				return err
 			}
 
-			outputWriter, err = os.Create(actualOutputFile)
-			if err != nil {
-				return fmt.Errorf("failed to create output file %s: %w", actualOutputFile, err)
-			}
-			defer func() {
-				if cerr := outputWriter.Close(); cerr != nil {
-					ctxLogger.Warn("failed to close output file", "error", cerr)
-				}
-			}()
 			ctxLogger = ctxLogger.WithFields("output_file", actualOutputFile)
-		} else {
-			outputWriter = os.Stdout
 		}
 
 		// Perform sanitization
@@ -250,15 +253,23 @@ RELATED:
 		default:
 		}
 
-		if err := s.SanitizeXML(file, outputWriter); err != nil {
+		// Sanitize into memory rather than straight into the destination file.
+		// os.Create truncates on open, so writing directly means any sanitizer
+		// failure leaves an empty or half-written file where the previous
+		// contents used to be. SanitizeXML already holds the whole document in
+		// memory (see its doc comment), so buffering the result does not change
+		// the command's memory profile in any meaningful way.
+		var sanitized bytes.Buffer
+		if err := s.SanitizeXML(file, &sanitized); err != nil {
 			return fmt.Errorf("failed to sanitize configuration: %w", err)
 		}
 
-		// Sync output file if writing to disk
 		if actualOutputFile != "" {
-			if err := outputWriter.Sync(); err != nil {
-				return fmt.Errorf("failed to sync output file: %w", err)
+			if err := writeSanitizeArtifact(actualOutputFile, sanitized.Bytes()); err != nil {
+				return fmt.Errorf("failed to write output file %s: %w", actualOutputFile, err)
 			}
+		} else if _, err := os.Stdout.Write(sanitized.Bytes()); err != nil {
+			return fmt.Errorf("failed to write sanitized output: %w", err)
 		}
 
 		// Log statistics
@@ -286,22 +297,8 @@ RELATED:
 				return fmt.Errorf("failed to generate mapping JSON: %w", err)
 			}
 
-			mappingWriter, err := os.Create(mappingPath)
-			if err != nil {
-				return fmt.Errorf("failed to create mapping file %s: %w", mappingPath, err)
-			}
-			defer func() {
-				if cerr := mappingWriter.Close(); cerr != nil {
-					ctxLogger.Warn("failed to close mapping file", "error", cerr)
-				}
-			}()
-
-			if _, err := mappingWriter.Write(mappingJSON); err != nil {
-				return fmt.Errorf("failed to write mapping file: %w", err)
-			}
-
-			if err := mappingWriter.Sync(); err != nil {
-				return fmt.Errorf("failed to sync mapping file: %w", err)
+			if err := writeSanitizeArtifact(mappingPath, mappingJSON); err != nil {
+				return fmt.Errorf("failed to write mapping file %s: %w", mappingPath, err)
 			}
 
 			ctxLogger.Debug("Mapping file written", "mapping_file", mappingPath)
@@ -318,6 +315,146 @@ RELATED:
 
 		return nil
 	},
+}
+
+// validateSanitizePaths rejects a run in which the input file, --output, and
+// --mapping do not all refer to distinct files.
+//
+// The case that matters is --output pointing at the input. os.Create truncates
+// on open, so without this guard the configuration is emptied before the
+// sanitizer reads a byte of it; the command then sanitizes an empty document,
+// writes nothing back, and exits 0 reporting "0 fields redacted". Operators run
+// sanitize against config.xml backups that are often the only copy on hand, and
+// neither --force nor answering the overwrite prompt is a meaningful gate here,
+// because both read as consent to replace the output, not the input.
+//
+// --mapping gets the same check, and --output is checked against --mapping
+// because the mapping file is written second and would otherwise replace the
+// sanitized configuration with the mapping JSON.
+//
+// inputPath is expected to be already absolute; outputPath and mappingPath are
+// taken as the operator supplied them and may be empty.
+func validateSanitizePaths(inputPath, outputPath, mappingPath string) error {
+	checks := []struct {
+		a, b    string
+		message string
+	}{
+		{
+			a: inputPath,
+			b: outputPath,
+			message: fmt.Sprintf(
+				"--output %s refers to the input file; sanitize never rewrites its input in place, and writing there would truncate the configuration before it is read. Write to a different path",
+				outputPath,
+			),
+		},
+		{
+			a: inputPath,
+			b: mappingPath,
+			message: fmt.Sprintf(
+				"--mapping %s refers to the input file; the mapping file would overwrite the configuration being sanitized. Write to a different path",
+				mappingPath,
+			),
+		},
+		{
+			a: outputPath,
+			b: mappingPath,
+			message: fmt.Sprintf(
+				"--output and --mapping both refer to %s; the mapping file is written second and would replace the sanitized configuration. Write them to different paths",
+				mappingPath,
+			),
+		},
+	}
+
+	for _, check := range checks {
+		if check.a == "" || check.b == "" {
+			continue
+		}
+
+		same, err := pathsResolveToSameFile(check.a, check.b)
+		if err != nil {
+			return err
+		}
+
+		if same {
+			return fmt.Errorf("%w: %s", ErrSanitizePathCollision, check.message)
+		}
+	}
+
+	return nil
+}
+
+// pathsResolveToSameFile reports whether two paths refer to the same file.
+//
+// Comparing the cleaned absolute paths covers the common case and is the only
+// signal available when neither file exists yet, which is normal for a pair of
+// output paths. When both paths do exist, os.SameFile is consulted as well:
+// os.Stat follows symlinks, so this also catches a destination that is a
+// symlink or hard link to the source, and on case-insensitive filesystems it
+// catches paths that differ only in case. A path that does not exist cannot
+// alias one that does, so a missing file is reported as no collision.
+func pathsResolveToSameFile(pathA, pathB string) (bool, error) {
+	absA, err := filepath.Abs(filepath.Clean(pathA))
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve absolute path for %s: %w", pathA, err)
+	}
+
+	absB, err := filepath.Abs(filepath.Clean(pathB))
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve absolute path for %s: %w", pathB, err)
+	}
+
+	if absA == absB {
+		return true, nil
+	}
+
+	infoA, err := os.Stat(absA)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to inspect %s: %w", pathA, err)
+	}
+
+	infoB, err := os.Stat(absB)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to inspect %s: %w", pathB, err)
+	}
+
+	return os.SameFile(infoA, infoB), nil
+}
+
+// writeSanitizeArtifact creates path, writes content, and flushes it to disk.
+// Close failures are returned rather than logged: a failed close can mean the
+// bytes never reached the filesystem, and this command exists to produce files
+// an operator is about to share.
+func writeSanitizeArtifact(path string, content []byte) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+
+	if _, err := file.Write(content); err != nil {
+		_ = file.Close()
+
+		return fmt.Errorf("write: %w", err)
+	}
+
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+
+		return fmt.Errorf("sync: %w", err)
+	}
+
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close: %w", err)
+	}
+
+	return nil
 }
 
 // determineSanitizeOutputPath determines whether the provided outputPath may be used.

--- a/cmd/sanitize_paths_test.go
+++ b/cmd/sanitize_paths_test.go
@@ -1,0 +1,477 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// sanitizeTestXML is a minimal but non-empty configuration used by the
+// regression tests below. It has to contain at least one redactable value so a
+// successful run reports a non-zero redaction count, which is what makes the
+// "0 fields redacted" success report on a destroyed input recognisable.
+const sanitizeTestXML = `<?xml version="1.0"?>
+<opnsense>
+  <system>
+    <hostname>firewall.example.com</hostname>
+    <user>
+      <name>admin</name>
+      <password>supersecret123</password>
+    </user>
+  </system>
+</opnsense>`
+
+func writeSanitizeFixture(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(sanitizeTestXML), 0o600); err != nil {
+		t.Fatalf("failed to write fixture %s: %v", path, err)
+	}
+}
+
+func TestPathsResolveToSameFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	existing := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, existing)
+
+	other := filepath.Join(tmpDir, "other.xml")
+	writeSanitizeFixture(t, other)
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{
+			name: "identical absolute paths",
+			a:    existing,
+			b:    existing,
+			want: true,
+		},
+		{
+			name: "distinct existing files",
+			a:    existing,
+			b:    other,
+			want: false,
+		},
+		{
+			name: "same file reached through a dot segment",
+			a:    existing,
+			b:    filepath.Join(tmpDir, ".", "config.xml"),
+			want: true,
+		},
+		{
+			name: "same file reached through a parent segment",
+			a:    existing,
+			b:    filepath.Join(tmpDir, "sub", "..", "config.xml"),
+			want: true,
+		},
+		{
+			name: "destination that does not exist yet",
+			a:    existing,
+			b:    filepath.Join(tmpDir, "sanitized.xml"),
+			want: false,
+		},
+		{
+			name: "two destinations that do not exist yet but share a path",
+			a:    filepath.Join(tmpDir, "out.xml"),
+			b:    filepath.Join(tmpDir, "out.xml"),
+			want: true,
+		},
+		{
+			name: "two destinations that do not exist yet with distinct paths",
+			a:    filepath.Join(tmpDir, "out.xml"),
+			b:    filepath.Join(tmpDir, "map.json"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pathsResolveToSameFile(tt.a, tt.b)
+			if err != nil {
+				t.Fatalf("pathsResolveToSameFile(%q, %q) returned error: %v", tt.a, tt.b, err)
+			}
+
+			if got != tt.want {
+				t.Errorf("pathsResolveToSameFile(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPathsResolveToSameFile_Symlink covers the case a purely lexical path
+// comparison cannot see: a destination that is a different path but resolves to
+// the input through a symlink. Creating symlinks needs elevation on Windows, so
+// the test skips rather than fails when the link cannot be created.
+func TestPathsResolveToSameFile_Symlink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	target := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, target)
+
+	link := filepath.Join(tmpDir, "config-link.xml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable on this platform or account: %v", err)
+	}
+
+	same, err := pathsResolveToSameFile(target, link)
+	if err != nil {
+		t.Fatalf("pathsResolveToSameFile returned error: %v", err)
+	}
+
+	if !same {
+		t.Error("a symlink pointing at the input should be reported as the same file")
+	}
+}
+
+func TestValidateSanitizePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	input := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, input)
+
+	output := filepath.Join(tmpDir, "sanitized.xml")
+	mapping := filepath.Join(tmpDir, "mapping.json")
+
+	tests := []struct {
+		name        string
+		input       string
+		output      string
+		mapping     string
+		wantErr     bool
+		wantMessage string
+	}{
+		{
+			name:    "all three distinct",
+			input:   input,
+			output:  output,
+			mapping: mapping,
+		},
+		{
+			name:  "output omitted",
+			input: input,
+		},
+		{
+			name:    "mapping omitted",
+			input:   input,
+			output:  output,
+			mapping: "",
+		},
+		{
+			name:        "output is the input",
+			input:       input,
+			output:      input,
+			wantErr:     true,
+			wantMessage: "refers to the input file",
+		},
+		{
+			name:        "mapping is the input",
+			input:       input,
+			output:      output,
+			mapping:     input,
+			wantErr:     true,
+			wantMessage: "refers to the input file",
+		},
+		{
+			name:        "output and mapping share a path",
+			input:       input,
+			output:      output,
+			mapping:     output,
+			wantErr:     true,
+			wantMessage: "both refer to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSanitizePaths(tt.input, tt.output, tt.mapping)
+
+			if !tt.wantErr {
+				if err != nil {
+					t.Fatalf("validateSanitizePaths returned unexpected error: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected a collision error, got nil")
+			}
+
+			if !errors.Is(err, ErrSanitizePathCollision) {
+				t.Errorf("error does not wrap ErrSanitizePathCollision: %v", err)
+			}
+
+			if !strings.Contains(err.Error(), tt.wantMessage) {
+				t.Errorf("error message %q does not contain %q", err.Error(), tt.wantMessage)
+			}
+		})
+	}
+}
+
+// resetFlagSet returns every flag in fs to its declared default and clears the
+// Changed bit.
+//
+// Cobra keeps Changed set for the lifetime of the command tree, and rootCmd is
+// a package-level singleton shared by the whole test binary. A --quiet from an
+// earlier test therefore still counts as "set" on the next Execute and trips
+// the verbose/quiet/debug mutual-exclusion group, which fails the run before it
+// reaches the command under test. None of these flags are slice-valued, so
+// Set(DefValue) round-trips cleanly.
+func resetFlagSet(t *testing.T, fs *pflag.FlagSet) {
+	t.Helper()
+
+	fs.VisitAll(func(f *pflag.Flag) {
+		if err := f.Value.Set(f.DefValue); err != nil {
+			t.Fatalf("failed to reset flag --%s to %q: %v", f.Name, f.DefValue, err)
+		}
+
+		f.Changed = false
+	})
+}
+
+// isolateCommandGlobals neutralises the package-level state Cobra binds its
+// flags to, both before the test runs and again when it ends.
+//
+// cfgFile matters as much as the flag state: other tests in this package leave
+// it pointing at a temp config that no longer exists, which makes
+// PersistentPreRunE fail during config load before the sanitize command is ever
+// reached. Clearing all of it keeps these tests independent of execution order.
+func isolateCommandGlobals(t *testing.T) {
+	t.Helper()
+
+	priorCfgFile := cfgFile
+
+	reset := func() {
+		sanitizeMode = SanitizeModeModerate
+		sanitizeOutputFile = ""
+		sanitizeMappingFile = ""
+		sanitizeForce = false
+
+		resetFlagSet(t, rootCmd.PersistentFlags())
+		resetFlagSet(t, sanitizeCmd.Flags())
+	}
+
+	t.Cleanup(func() {
+		reset()
+
+		cfgFile = priorCfgFile
+
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	reset()
+
+	cfgFile = ""
+}
+
+// runSanitize executes the sanitize command through the root command, the same
+// path a real invocation takes, and returns its error.
+func runSanitize(t *testing.T, args ...string) error {
+	t.Helper()
+
+	isolateCommandGlobals(t)
+
+	var out bytes.Buffer
+
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs(append([]string{"sanitize"}, args...))
+
+	return rootCmd.Execute()
+}
+
+// TestSanitizeCommand_RefusesToDestroyInput is the regression test for the
+// in-place truncation bug. Before the fix, each of these invocations opened the
+// destination with os.Create, which truncated the file the sanitizer was about
+// to read; the command then sanitized an empty document and exited 0 reporting
+// "0 fields redacted", leaving the operator with a zero-byte configuration.
+//
+// The assertion that matters is not just that the command fails, but that the
+// input file is byte-for-byte unchanged afterwards.
+func TestSanitizeCommand_RefusesToDestroyInput(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(input string) []string
+	}{
+		{
+			name: "output aimed at the input",
+			args: func(input string) []string {
+				return []string{input, "-o", input, "--force"}
+			},
+		},
+		{
+			name: "mapping aimed at the input",
+			args: func(input string) []string {
+				return []string{input, "--mapping", input, "--force"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			input := filepath.Join(tmpDir, "config.xml")
+			writeSanitizeFixture(t, input)
+
+			err := runSanitize(t, tt.args(input)...)
+			if err == nil {
+				t.Fatal("expected the command to fail, got nil error")
+			}
+
+			if !errors.Is(err, ErrSanitizePathCollision) {
+				t.Errorf("error does not wrap ErrSanitizePathCollision: %v", err)
+			}
+
+			after, readErr := os.ReadFile(input)
+			if readErr != nil {
+				t.Fatalf("failed to read input file after the run: %v", readErr)
+			}
+
+			if !bytes.Equal(after, []byte(sanitizeTestXML)) {
+				t.Errorf("input file was modified; got %d bytes, want %d bytes",
+					len(after), len(sanitizeTestXML))
+			}
+		})
+	}
+}
+
+// TestSanitizeCommand_RefusesRelativeAliasOfInput checks the same guard when the
+// operator spells the destination differently from the input. A lexical
+// comparison of the raw strings would miss this.
+func TestSanitizeCommand_RefusesRelativeAliasOfInput(t *testing.T) {
+	tmpDir := t.TempDir()
+	input := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, input)
+
+	alias := filepath.Join(tmpDir, "sub", "..", "config.xml")
+
+	err := runSanitize(t, input, "-o", alias, "--force")
+	if err == nil {
+		t.Fatal("expected the command to fail, got nil error")
+	}
+
+	if !errors.Is(err, ErrSanitizePathCollision) {
+		t.Errorf("error does not wrap ErrSanitizePathCollision: %v", err)
+	}
+
+	after, readErr := os.ReadFile(input)
+	if readErr != nil {
+		t.Fatalf("failed to read input file after the run: %v", readErr)
+	}
+
+	if !bytes.Equal(after, []byte(sanitizeTestXML)) {
+		t.Error("input file was modified by a run that should have been rejected")
+	}
+}
+
+// TestSanitizeCommand_WritesDistinctDestinations is the counterpart to the
+// rejection tests: the guard must not get in the way of an ordinary run.
+func TestSanitizeCommand_WritesDistinctDestinations(t *testing.T) {
+	tmpDir := t.TempDir()
+	input := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, input)
+
+	output := filepath.Join(tmpDir, "sanitized.xml")
+	mapping := filepath.Join(tmpDir, "mapping.json")
+
+	if err := runSanitize(t, input, "-o", output, "--mapping", mapping, "--force"); err != nil {
+		t.Fatalf("sanitize with distinct destinations failed: %v", err)
+	}
+
+	sanitized, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("failed to read sanitized output: %v", err)
+	}
+
+	if len(sanitized) == 0 {
+		t.Error("sanitized output is empty")
+	}
+
+	if bytes.Contains(sanitized, []byte("supersecret123")) {
+		t.Error("password was not redacted in the sanitized output")
+	}
+
+	if _, err := os.Stat(mapping); err != nil {
+		t.Errorf("mapping file was not written: %v", err)
+	}
+
+	unchanged, err := os.ReadFile(input)
+	if err != nil {
+		t.Fatalf("failed to read input file after the run: %v", err)
+	}
+
+	if !bytes.Equal(unchanged, []byte(sanitizeTestXML)) {
+		t.Error("input file was modified by a successful run")
+	}
+}
+
+// TestSanitizeCommand_FailedRunLeavesDestinationIntact covers the second half of
+// the fix: the destination is created only after sanitization succeeds, so a
+// failure part-way through cannot leave a truncated file where a previous
+// result used to be.
+func TestSanitizeCommand_FailedRunLeavesDestinationIntact(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	input := filepath.Join(tmpDir, "config.xml")
+	if err := os.WriteFile(input, []byte("<opnsense><system>"), 0o600); err != nil {
+		t.Fatalf("failed to write malformed fixture: %v", err)
+	}
+
+	const previous = "previous sanitized output"
+
+	output := filepath.Join(tmpDir, "sanitized.xml")
+	if err := os.WriteFile(output, []byte(previous), 0o600); err != nil {
+		t.Fatalf("failed to seed destination: %v", err)
+	}
+
+	if err := runSanitize(t, input, "-o", output, "--force"); err == nil {
+		t.Fatal("expected sanitizing a malformed document to fail, got nil error")
+	}
+
+	after, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("failed to read destination after the failed run: %v", err)
+	}
+
+	if string(after) != previous {
+		t.Errorf("destination was clobbered by a failed run; got %q, want %q", string(after), previous)
+	}
+}
+
+// TestPathsResolveToSameFile_CaseInsensitive exercises the os.SameFile arm of
+// the check on filesystems where two spellings of one path differ only in case.
+// Linux filesystems are case-sensitive, so the two names are genuinely
+// different files there and the test only runs on Windows and macOS.
+func TestPathsResolveToSameFile_CaseInsensitive(t *testing.T) {
+	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+		t.Skip("filesystem is case-sensitive on this platform")
+	}
+
+	tmpDir := t.TempDir()
+
+	lower := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, lower)
+
+	upper := filepath.Join(tmpDir, "CONFIG.XML")
+
+	same, err := pathsResolveToSameFile(lower, upper)
+	if err != nil {
+		t.Fatalf("pathsResolveToSameFile returned error: %v", err)
+	}
+
+	if !same {
+		t.Error("paths differing only in case should resolve to the same file on this platform")
+	}
+}

--- a/cmd/sanitize_paths_test.go
+++ b/cmd/sanitize_paths_test.go
@@ -475,3 +475,86 @@ func TestPathsResolveToSameFile_CaseInsensitive(t *testing.T) {
 		t.Error("paths differing only in case should resolve to the same file on this platform")
 	}
 }
+
+// TestSanitizeArtifactsAreOwnerOnly checks the permissions of both files the
+// command creates. The mapping file is the sensitive one: it holds every
+// original hostname, address, username, and email in cleartext next to its
+// pseudonym, so a 0644 default in a shared working directory would undo much of
+// the point of sanitizing.
+//
+// The mode bits are POSIX-only; NTFS does not map onto FileMode.Perm(), so the
+// assertion is skipped on Windows rather than asserted and quietly wrong.
+func TestSanitizeArtifactsAreOwnerOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits do not map onto NTFS ACLs")
+	}
+
+	tmpDir := t.TempDir()
+	input := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, input)
+
+	output := filepath.Join(tmpDir, "sanitized.xml")
+	mapping := filepath.Join(tmpDir, "mapping.json")
+
+	if err := runSanitize(t, input, "-o", output, "--mapping", mapping, "--force"); err != nil {
+		t.Fatalf("sanitize failed: %v", err)
+	}
+
+	for _, path := range []string{output, mapping} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("failed to stat %s: %v", path, err)
+		}
+
+		if got := info.Mode().Perm(); got != sanitizeArtifactPermissions {
+			t.Errorf("%s has mode %#o, want %#o", filepath.Base(path), got, sanitizeArtifactPermissions)
+		}
+	}
+}
+
+// TestSanitizeTightensExistingArtifactPermissions covers the case the OpenFile
+// mode argument alone does not: the target already exists, so O_CREATE does not
+// apply a mode to it. Re-running sanitize over a mapping file that an earlier
+// version left world-readable has to end with it owner-only.
+func TestSanitizeTightensExistingArtifactPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits do not map onto NTFS ACLs")
+	}
+
+	tmpDir := t.TempDir()
+	input := filepath.Join(tmpDir, "config.xml")
+	writeSanitizeFixture(t, input)
+
+	output := filepath.Join(tmpDir, "sanitized.xml")
+	mapping := filepath.Join(tmpDir, "mapping.json")
+
+	// Seed both destinations world-readable, as an earlier release would have
+	// left them. Written owner-only first and widened with Chmod so the fixture
+	// setup does not itself trip the write-permission linter.
+	const worldReadable = 0o644
+
+	for _, path := range []string{output, mapping} {
+		if err := os.WriteFile(path, []byte("stale"), sanitizeArtifactPermissions); err != nil {
+			t.Fatalf("failed to seed %s: %v", path, err)
+		}
+
+		if err := os.Chmod(path, worldReadable); err != nil {
+			t.Fatalf("failed to widen permissions on %s: %v", path, err)
+		}
+	}
+
+	if err := runSanitize(t, input, "-o", output, "--mapping", mapping, "--force"); err != nil {
+		t.Fatalf("sanitize failed: %v", err)
+	}
+
+	for _, path := range []string{output, mapping} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("failed to stat %s: %v", path, err)
+		}
+
+		if got := info.Mode().Perm(); got != sanitizeArtifactPermissions {
+			t.Errorf("%s kept mode %#o, want %#o", filepath.Base(path), got, sanitizeArtifactPermissions)
+		}
+	}
+}


### PR DESCRIPTION
## Description

`opnDossier sanitize config.xml -o config.xml` deletes the configuration and exits 0.

The command opens the input for reading, then calls `os.Create` on the destination, which truncates on open. When both paths resolve to the same file, the input is emptied before the sanitizer reads a byte of it. The run then sanitizes an empty document, writes nothing back, and reports success:

```console
$ ls -l selftest.xml
-rw------- 1 user user 12451 Aug 17 04:31 selftest.xml

$ opnDossier sanitize selftest.xml -o selftest.xml --force
Sanitized selftest.xml -> selftest.xml (0 fields redacted)

$ echo $?
0

$ ls -l selftest.xml
-rw------- 1 user user 0 Aug 17 04:31 selftest.xml
```

Two things make this worse than an ordinary footgun:

1. Neither `--force` nor answering `y` at the overwrite prompt is a meaningful gate. Both read as consent to replace the *output*, and an operator has no reason to think they are consenting to destroy the *input*.
2. The command's own help text promises the opposite. `sanitize --help` currently says "Sanitize never modifies the input in place", and the summary line even reports a redaction count, so nothing in the output suggests anything went wrong.

The realistic exposure is that `sanitize` is the command you reach for when handling a `config.xml` you are about to share, which is very often a firewall backup and frequently the only copy on the machine at that moment.

The same failure mode applies to `--mapping`, and `--output` and `--mapping` pointing at one another silently replaces the sanitized configuration with the mapping JSON.

## Type of Change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Related Issues

No existing issue. Found while auditing the file-writing paths in `cmd/`.

## Key Changes

### 1. Reject colliding paths before anything is opened for writing

New `validateSanitizePaths` runs immediately after the input path is resolved and before `os.Open`, and rejects a run in which the input file, `--output`, and `--mapping` do not all refer to distinct files. It checks three pairs:

| Pair | Failure prevented |
| --- | --- |
| input vs `--output` | input truncated before it is read |
| input vs `--mapping` | input replaced by the mapping JSON |
| `--output` vs `--mapping` | sanitized config replaced by the mapping JSON, since the mapping is written second |

Collision detection lives in `pathsResolveToSameFile`. It compares cleaned absolute paths first, which is the only signal available when neither file exists yet (the normal case for two destination paths), and then falls back to `os.SameFile` when both paths do exist. `os.Stat` follows symlinks, so the second arm also catches a destination that reaches the input through a symlink, a hard link, a relative alias such as `sub/../config.xml`, or a spelling that differs only in case on a case-insensitive filesystem. A path that does not exist cannot alias one that does, so a missing destination is correctly reported as no collision.

The resulting error names the offending flag, the path, and what to do:

```console
$ opnDossier sanitize config.xml -o config.xml --force
ERROR  Sanitize path collision: --output /home/op/config.xml refers to the input file;
       sanitize never rewrites its input in place, and writing there would truncate the
       configuration before it is read. Write to a different path.

$ echo $?
1
```

It wraps `ErrSanitizePathCollision` so callers and tests can match on it with `errors.Is`.

### 2. Create the destination only after sanitization succeeds

Previously the destination was opened with `os.Create` and handed straight to `SanitizeXML` as the writer, so any sanitizer failure left an empty or half-written file where the previous result used to be. The document is now sanitized into a buffer, and the destination is created only once that returns cleanly.

This does not change the command's memory profile in any meaningful way. `SanitizeXML` already reads the entire input into memory and builds the complete output in a `strings.Builder` before writing it in a single call, which its own doc comment documents as an intentional tradeoff.

### 3. Share one writer for both artifacts

The sanitized config and the mapping file now both go through `writeSanitizeArtifact`, which replaces two near-identical create/write/sync/close blocks. It returns close failures rather than logging them, since a failed close can mean the bytes never reached the filesystem, and this command exists to produce files an operator is about to hand to someone else.

### 4. Fix the contradiction in the help text

`sanitize --help` claimed both that the command "rewrites the source config.xml itself" and, twelve lines later, that it "never modifies the input in place". The first now reads "produces a redacted copy of the config.xml itself. The input file is never modified."

## Files Modified

- `cmd/sanitize.go` - the guard, the deferred destination creation, the shared writer, owner-only permissions, the help text correction
- `cmd/sanitize_paths_test.go` - new, regression coverage

## Testing

### New tests

`cmd/sanitize_paths_test.go` covers the fix at two levels.

Unit level:

- `TestPathsResolveToSameFile` is table driven over identical paths, distinct files, dot and parent segments resolving back to the input, a destination that does not exist yet, two non-existent destinations sharing a path, and two non-existent destinations with distinct paths.
- `TestPathsResolveToSameFile_Symlink` covers the case a lexical comparison cannot see. It skips rather than fails where symlink creation needs elevation.
- `TestPathsResolveToSameFile_CaseInsensitive` exercises the `os.SameFile` arm, and skips on case-sensitive filesystems where the two names really are different files.
- `TestValidateSanitizePaths` is table driven over all three colliding pairs plus the distinct and omitted-flag cases.

Command level, driven through `rootCmd.Execute()` so the assertions cover the path a real invocation takes:

- `TestSanitizeCommand_RefusesToDestroyInput` runs `-o <input>` and `--mapping <input>`. The assertion that matters is not just that the command fails, it is that the input file is byte-for-byte unchanged afterwards.
- `TestSanitizeCommand_RefusesRelativeAliasOfInput` does the same with a destination spelled differently from the input.
- `TestSanitizeCommand_WritesDistinctDestinations` is the counterpart, confirming the guard does not get in the way of an ordinary run and that the password in the fixture is still redacted.
- `TestSanitizeCommand_FailedRunLeavesDestinationIntact` seeds a destination with previous content, sanitizes a malformed document, and asserts the destination still holds the previous content.
- `TestSanitizeArtifactsAreOwnerOnly` and `TestSanitizeTightensExistingArtifactPermissions` cover the mode on new and pre-existing destinations. Both skip on Windows.

### Adversarial matrix run against the built binary

Reasoning about which aliases `os.Stat` plus `os.SameFile` catches is not the same as checking, so I built the binary and ran each shape. Every rejection also asserts the input file is byte-for-byte unchanged.

| Case | Expected | Result |
| --- | --- | --- |
| `-o` equal to the input | reject | exit 1, input intact |
| `-o` via a `.` segment | reject | exit 1, input intact |
| `-o` via a `sub/..` segment | reject | exit 1, input intact |
| `-o` differing only in case | reject | exit 1, input intact |
| `-o` a hard link to the input | reject | exit 1, input intact |
| `-o` a symlink to the input | reject | exit 1, input intact |
| `-o` through a symlinked parent directory | reject | exit 1, input intact |
| relative paths from the working directory | reject | exit 1, input intact |
| `--mapping` equal to the input | reject | exit 1, input intact |
| `--output` equal to `--mapping` | reject | exit 1, input intact |
| `-o` a distinct path | allow | exit 0, input intact |
| stdout mode, no `-o` | allow | exit 0, input intact |
| malformed input over an existing `-o` | reject | exit 1, prior output intact |

The case-variant and symlinked-parent rows are the ones worth noting: both are caught by the `os.SameFile` arm rather than the lexical compare, because `os.Stat` resolves the whole path before the comparison happens.

### Test isolation note for reviewers

The command-level tests needed an `isolateCommandGlobals` helper, and it is worth flagging why rather than leaving it as unexplained scaffolding.

`rootCmd` is a package-level singleton shared by the whole test binary, and two kinds of state leak across `Execute()` calls in this package. `cfgFile` is left pointing at a temp config that no longer exists, which fails `PersistentPreRunE` during config load before the command under test is reached. Separately, Cobra keeps `flag.Changed` set for the lifetime of the command tree, so a `--quiet` from an earlier test still counts as set and trips the `verbose/quiet/debug` mutual-exclusion group. The helper clears both before and after each test. This is also why the existing `TestSanitizeCommandIntegration` calls the sanitizer package directly and notes that it does so to avoid "test isolation issues with the full command chain".

### Verification with a built binary

```console
$ go build -o opnd .
$ cp testdata/sample.config.1.xml selftest.xml
$ ls -l selftest.xml          # 12451 bytes
$ ./opnd sanitize selftest.xml -o selftest.xml --force
ERROR  Sanitize path collision: --output ... refers to the input file; ...
$ echo $?                     # 1
$ ls -l selftest.xml          # 12451 bytes, unchanged
```

### Test Results

```console
$ golangci-lint run ./...
0 issues.

$ golangci-lint fmt --diff ./cmd/...
(no output)

$ go test ./cmd/ ./internal/sanitizer/ -count=1
ok      github.com/EvilBit-Labs/opnDossier/cmd              1.605s
ok      github.com/EvilBit-Labs/opnDossier/internal/sanitizer  0.452s
```

Full `go test ./...` on this branch was run on Windows. `internal/converter` (`TestGolden_ProgrammaticReportGeneration`) and `internal/export` (four `TestFileExporter_*` cases) fail there. Both failures reproduce on `main` at `0807124` with this branch's changes stashed, so they are pre-existing and unrelated to this PR. They are not visible in CI because the Windows job runs `just ci-smoke`, which is limited to `./cmd/...` and `./internal/config/...`.

The new tests are order independent. Running `go test ./cmd/ -shuffle=on` repeatedly on this branch and on a stashed baseline produces the same set of pre-existing order-dependent failures (`TestConvertCmdWithInvalidFile`, `TestConvertCmdWithValidXML`, `TestDisplayCommand*`, `TestListDevices_*`) in both cases, and none of the sanitize tests appear in either list.

## Artifact permissions

Both writes used `os.Create`, which is 0666 masked by umask and so typically 0644, while every other command in this tool writes through `export.FileExporter` at 0600. The `--mapping` file is the one that matters: it is the reverse-lookup table, holding every original hostname, address, username, and email in cleartext next to its pseudonym, written into whatever directory the operator happens to be standing in.

Both artifacts are now created `0600`, with an explicit `Chmod` after `OpenFile`. That is not redundant: the mode argument applies to newly created files only, so re-running sanitize over a mapping file an earlier version left at 0644 would otherwise keep it world-readable, which is exactly the case worth fixing.

I scoped this out of the first commit as a separate concern and that was wrong, because the `os.Create` sits in a helper this PR introduces. Shipping it as written would have meant newly writing a cleartext secret map world-readable rather than inheriting the problem from somewhere else.

Two tests cover it, both skipped on Windows because NTFS ACLs do not map onto `FileMode.Perm()`: one asserts the mode on freshly created artifacts, the other seeds both destinations at 0644 and asserts sanitize tightens them. **I could not execute the permission assertions locally**, since this machine is Windows with no WSL distro or Docker available. They are enforced by the Linux CI job rather than by my having run them.

## Compatibility

No breaking change for any invocation that was previously doing something sensible.

The only invocations that now fail are the ones that were destroying data or silently discarding one of the two outputs. Every combination of distinct paths behaves exactly as before, including stdout output, `--force`, the overwrite prompt, `--mapping`, and all three modes. Exit codes for existing failure paths are unchanged.

## Deliberately Out of Scope

**Atomic replace.** Routing both writes through `export.FileExporter` would give temp-file-plus-rename for free, but `FileExporter.Export` also runs `checkPathTraversal`, which rejects relative paths resolving outside the working directory. I verified both halves of that rather than reading it off the source:

```console
$ opnDossier sanitize config.xml -o ../out.xml --force
Sanitized config.xml -> ..\out.xml (2 fields redacted)          # exit 0, works today

$ opnDossier convert config.xml -o ../out.md --force             # same helper, via FileExporter
ERROR  export validate_path failed for ..\out.md: path contains
       potentially malicious traversal sequences                 # exit 1, no file
```

So adopting `FileExporter` here would break a currently working invocation. Creating the destination only after sanitization succeeds gets most of the safety benefit without that regression, and whether `checkPathTraversal` should be rejecting `../` for a user-named output file at all is a better question to settle on its own.

File permissions were originally listed here too. That was the wrong call and they are now fixed in this PR; see the section above.

## Security Considerations

This closes a data-destruction path rather than an information-disclosure one. No new attack surface: the guard only adds `os.Stat` calls on paths the command was already going to open. The `--mapping` permissions point above is a genuine disclosure issue but is left for a separate change.

## Performance Impact

Negligible. Up to three additional `filepath.Abs` calls and up to four additional `os.Stat` calls, once per invocation. Buffering the sanitized document adds one copy of the output alongside the copies `SanitizeXML` already holds.

## Pre-submission Checklist

- [x] **Code Quality**: `golangci-lint fmt --diff` clean
- [x] **Linting**: `golangci-lint run ./...` reports 0 issues
- [x] **Tests**: new tests added, `./cmd/` and `./internal/sanitizer/` pass
- [x] **Error Handling**: errors wrapped with context, sentinel exposed for `errors.Is`
- [x] **Documentation**: new functions carry godoc comments, help text corrected
- [x] **Dependencies**: none added
- [x] **Security**: no hardcoded secrets
- [x] **Input Validation**: this PR is input validation
