### PR TITLE
ci: run the race detector, and stop wall-clock tests from blocking it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           install: true
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,32 @@ jobs:
         run: go test -tags=integration -v -timeout 5m ./...
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Race Detector
+  #
+  # Previously excluded because the suite could not survive it on a shared
+  # runner: TestPerformanceBaselines asserts sub-millisecond latencies, and
+  # race instrumentation made those fail every run under load while passing
+  # every run without it. Those assertions now skip under -race and the
+  # cancellation bounds scale with it, so the detector runs the full suite
+  # here. Concurrency-sensitive tests are NOT skipped; -short is deliberately
+  # not used, since it would drop the stress tests this job exists to cover.
+  # ─────────────────────────────────────────────────────────────────────────
+  race:
+    name: Race Detector
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run tests with race detector
+        run: just test-race
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Coverage - Generate and upload coverage report
   # ─────────────────────────────────────────────────────────────────────────
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,11 @@ jobs:
   # runner: TestPerformanceBaselines asserts sub-millisecond latencies, and
   # race instrumentation made those fail every run under load while passing
   # every run without it. Those assertions now skip under -race and the
-  # cancellation bounds scale with it, so the detector runs the full suite
-  # here. Concurrency-sensitive tests are NOT skipped; -short is deliberately
+  # cancellation bounds scale with it, so the detector runs the suite here.
+  # Tests that build and run the binary as a subprocess also skip: the child
+  # is compiled without -race, so the detector cannot observe it, and the
+  # cold cross-flavor build alone overruns their 30-second budgets.
+  # Concurrency-sensitive tests are NOT skipped; -short is deliberately
   # not used, since it would drop the stress tests this job exists to cover.
   # ─────────────────────────────────────────────────────────────────────────
   race:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,6 +41,7 @@ queue_rules:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
+      - check-success = Race Detector
 
   # ─────────────────────────────────────────────────────────────────────────
   # 4. default — manually enqueued by maintainers, full CI
@@ -56,6 +57,7 @@ queue_rules:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
+      - check-success = Race Detector
 
 pull_request_rules:
   # ─────────────────────────────────────────────────────────────────────────
@@ -131,6 +133,7 @@ merge_protections:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
+      - check-success = Race Detector
 
   # ─────────────────────────────────────────────────────────────────────────
   # 3. Lint-only for bots with workflow-only changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ just ci-check
 
 It is intentionally **not** wired to a git hook. A prior iteration added a pre-push `just ci-check` hook, but non-interactive push clients (including Copilot agents) could not recover when the hook failed and discarded the session. Developer discipline replaces automation here — CI runs the subset it can host, and `just ci-check` remains the locally-runnable gate.
 
-**Race detector note.** `test-race` (the Go race detector) runs in CI as its own job and locally via `just test-race` or `just ci-check`. It was previously local-only because the suite's wall-clock assertions failed under instrumentation on a shared runner; those now skip or scale under `-race` (GOTCHAS §1.2). If you add a timing bound to a test, decide what it does under the detector before pushing.
+**Race detector note.** `test-race` (the Go race detector) runs in CI as its own job and locally via `just test-race` or `just ci-check`. It was previously local-only because the suite's wall-clock assertions failed under instrumentation on a shared runner; those now skip or scale under `-race` (GOTCHAS §1.6). If you add a timing bound to a test, decide what it does under the detector before pushing.
 
 ### Known Gotchas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ just ci-check
 
 It is intentionally **not** wired to a git hook. A prior iteration added a pre-push `just ci-check` hook, but non-interactive push clients (including Copilot agents) could not recover when the hook failed and discarded the session. Developer discipline replaces automation here — CI runs the subset it can host, and `just ci-check` remains the locally-runnable gate.
 
-**Race detector note.** `test-race` (the Go race detector) cannot be hosted reliably on GitHub Actions runners, so it runs only via `just ci-check` locally. If you're touching `cmd/` global-flag tests (GOTCHAS §1.1) or anything concurrency-sensitive, run `just test-race` before pushing.
+**Race detector note.** `test-race` (the Go race detector) runs in CI as its own job and locally via `just test-race` or `just ci-check`. It was previously local-only because the suite's wall-clock assertions failed under instrumentation on a shared runner; those now skip or scale under `-race` (GOTCHAS §1.2). If you add a timing bound to a test, decide what it does under the detector before pushing.
 
 ### Known Gotchas
 

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -13,14 +13,6 @@ The `cmd/` package uses package-level global variables for CLI flags (required b
 - **Solution:** Remove `t.Parallel()` from the parent test and all subtests that interact with global flags. Use `t.Cleanup()` to restore original global values after the test.
 - **Enforcement:** The `.golangci.yml` `forbidigo` rule forbids `t.Parallel()` anywhere in `cmd/` — catches the regression at lint time. The race detector runs in CI (the `Race Detector` job in `.github/workflows/ci.yml`) and locally via `just test-race` (or `just ci-check`). A prior pre-push `just ci-check` hook broke non-interactive push clients, so the full gate is still not wired to a git hook. See [CONTRIBUTING.md § Git Hooks](CONTRIBUTING.md#git-hooks) for the current setup.
 
-### 1.2 Wall-Clock Assertions and `-race`
-
-Race instrumentation multiplies execution cost, so a latency assertion calibrated without it measures the instrumentation. On a loaded machine `TestPerformanceBaselines` failed 10 of 10 runs under `-race` and passed 10 of 10 without it, which is why the detector was previously kept out of CI.
-
-- **Rule:** never add a wall-clock upper bound to a test without deciding what it does under `-race`.
-- **Pattern:** `internal/testing/racedetect.Enabled` is a build-tagged constant. Skip the assertion when the test is a latency baseline (`TestPerformanceBaselines`), or scale the bound when the bound is a coarse guard rather than a measurement (`cancelAbortBudget` in `internal/converter`, which only needs to tell "aborted" apart from "generated the whole document").
-- **Do not** reach for `-short` to dodge this. It also skips the stress and thread-safety tests, which are the ones most worth running under the detector.
-
 ### 1.2 Race Detector Collateral
 
 When a data race occurs in a test touching global state, the Go race detector may report collateral races in unrelated, stateless functions (e.g., `truncateString` or `escapePipeForMarkdown`) that happen to be running in other parallel tests.
@@ -50,6 +42,14 @@ The `.golangci.yml` `gocognit` linter is configured to fail at cognitive complex
 - **Fix pattern:** extract per-variant closures into helper functions returning `func(*testing.B)` (e.g., `runMultiFormatGenerate(ctx, gen, device, formats, preEnrich) func(*testing.B)`). Each helper drops the cognitive count of the enclosing function below the threshold without changing the test surface.
 - **Don't:** add `//nolint:gocognit` to mask it. The threshold catches a real readability drift; helper extraction fixes both the lint and the readability.
 - **Recurrence vector:** any test/benchmark orchestration function that grows from 2 to 4+ dispatch arms inside a `for _, tc := range cases` loop.
+
+### 1.6 Wall-Clock Assertions and `-race`
+
+Race instrumentation multiplies execution cost, so a latency assertion calibrated without it measures the instrumentation. On a loaded machine `TestPerformanceBaselines` failed 10 of 10 runs under `-race` and passed 10 of 10 without it, which is why the detector was previously kept out of CI.
+
+- **Rule:** never add a wall-clock upper bound to a test without deciding what it does under `-race`.
+- **Pattern:** `internal/testing/racedetect.Enabled` is a build-tagged constant. Skip the assertion when the test is a latency baseline (`TestPerformanceBaselines`), or scale the bound when the bound is a coarse guard rather than a measurement (`cancelAbortBudget` in `internal/converter`, which only needs to tell "aborted" apart from "generated the whole document").
+- **Do not** reach for `-short` to dodge this. It also skips the stress and thread-safety tests, which are the ones most worth running under the detector.
 
 ## 2. Plugin Architecture
 

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -11,7 +11,15 @@ The `cmd/` package uses package-level global variables for CLI flags (required b
 - **Problem:** Concurrent tests modifying `sharedDeviceType`, `sharedAuditMode`, or the `rootCmd` flag set will cause non-deterministic data races.
 - **Symptom:** `just test-race` fails with "DATA RACE" reports in the `cmd` package.
 - **Solution:** Remove `t.Parallel()` from the parent test and all subtests that interact with global flags. Use `t.Cleanup()` to restore original global values after the test.
-- **Enforcement:** The `.golangci.yml` `forbidigo` rule forbids `t.Parallel()` anywhere in `cmd/` — catches the regression at lint time. The race detector itself runs only locally via `just test-race` (or `just ci-check`); CI cannot host it reliably, and a prior pre-push `just ci-check` hook broke non-interactive push clients. See [CONTRIBUTING.md § Git Hooks](CONTRIBUTING.md#git-hooks) for the current setup.
+- **Enforcement:** The `.golangci.yml` `forbidigo` rule forbids `t.Parallel()` anywhere in `cmd/` — catches the regression at lint time. The race detector runs in CI (the `Race Detector` job in `.github/workflows/ci.yml`) and locally via `just test-race` (or `just ci-check`). A prior pre-push `just ci-check` hook broke non-interactive push clients, so the full gate is still not wired to a git hook. See [CONTRIBUTING.md § Git Hooks](CONTRIBUTING.md#git-hooks) for the current setup.
+
+### 1.2 Wall-Clock Assertions and `-race`
+
+Race instrumentation multiplies execution cost, so a latency assertion calibrated without it measures the instrumentation. On a loaded machine `TestPerformanceBaselines` failed 10 of 10 runs under `-race` and passed 10 of 10 without it, which is why the detector was previously kept out of CI.
+
+- **Rule:** never add a wall-clock upper bound to a test without deciding what it does under `-race`.
+- **Pattern:** `internal/testing/racedetect.Enabled` is a build-tagged constant. Skip the assertion when the test is a latency baseline (`TestPerformanceBaselines`), or scale the bound when the bound is a coarse guard rather than a measurement (`cancelAbortBudget` in `internal/converter`, which only needs to tell "aborted" apart from "generated the whole document").
+- **Do not** reach for `-short` to dodge this. It also skips the stress and thread-safety tests, which are the ones most worth running under the detector.
 
 ### 1.2 Race Detector Collateral
 

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -49,6 +49,7 @@ Race instrumentation multiplies execution cost, so a latency assertion calibrate
 
 - **Rule:** never add a wall-clock upper bound to a test without deciding what it does under `-race`.
 - **Pattern:** `internal/testing/racedetect.Enabled` is a build-tagged constant. Skip the assertion when the test is a latency baseline (`TestPerformanceBaselines`), or scale the bound when the bound is a coarse guard rather than a measurement (`cancelAbortBudget` in `internal/converter`, which only needs to tell "aborted" apart from "generated the whole document").
+- **Subprocess builds:** a test that shells out to `go build` gets no benefit from a `-race` run (the child is not instrumented) and pays for it twice: the build cache holds only race-flavored artifacts, so the child compiles cold, and a deadline calibrated against a warm cache kills it. `build_test.go` skips under `racedetect.Enabled` for exactly this reason.
 - **Do not** reach for `-short` to dodge this. It also skips the stress and thread-safety tests, which are the ones most worth running under the detector.
 
 ## 2. Plugin Architecture

--- a/build_test.go
+++ b/build_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/EvilBit-Labs/opnDossier/internal/testing/racedetect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -123,13 +124,30 @@ func (s *BuildTestSuite) TestBinaryConvert() {
 	s.Require().NoError(err, "convert should succeed, output: %s", output)
 }
 
+// skipIfRaceBuild skips the tests in this file under -race. They build the
+// binary with a plain `go build`, so the child process carries no race
+// instrumentation and the detector cannot observe anything it executes. All a
+// -race run adds is a cold build: the cache holds only race-flavored
+// artifacts, and the fresh compile alone overruns the 30-second budget on a
+// shared runner. The regular test jobs still run these on every push.
+func skipIfRaceBuild(t *testing.T) {
+	t.Helper()
+
+	if racedetect.Enabled {
+		t.Skip("Skipping subprocess build tests under -race: the child binary is not instrumented")
+	}
+}
+
 // TestBuildTestSuite runs the build test suite.
 func TestBuildTestSuite(t *testing.T) {
+	skipIfRaceBuild(t)
 	suite.Run(t, new(BuildTestSuite))
 }
 
 // TestBinaryHelp_Standalone verifies the binary builds and shows help.
 func TestBinaryHelp_Standalone(t *testing.T) {
+	skipIfRaceBuild(t)
+
 	if testing.Short() {
 		t.Skip("Skipping build test in short mode")
 	}
@@ -169,6 +187,8 @@ func TestBinaryHelp_Standalone(t *testing.T) {
 
 // TestBinaryConvert_Standalone verifies the binary can convert a config file.
 func TestBinaryConvert_Standalone(t *testing.T) {
+	skipIfRaceBuild(t)
+
 	if testing.Short() {
 		t.Skip("Skipping build conversion test in short mode")
 	}

--- a/internal/converter/hybrid_generator_test.go
+++ b/internal/converter/hybrid_generator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/EvilBit-Labs/opnDossier/internal/converter/builder"
 	"github.com/EvilBit-Labs/opnDossier/internal/logging"
+	"github.com/EvilBit-Labs/opnDossier/internal/testing/racedetect"
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -779,7 +780,7 @@ func TestHybridGenerator_Generate_RespectsCanceledContext(t *testing.T) {
 
 			require.ErrorIs(t, err, context.Canceled,
 				"pre-canceled ctx must surface as context.Canceled")
-			assert.Less(t, dur, 50*time.Millisecond,
+			assert.Less(t, dur, cancelAbortBudget,
 				"cancellation must abort promptly, got %v", dur)
 		})
 	}
@@ -810,8 +811,24 @@ func TestHybridGenerator_GenerateToWriter_RespectsCanceledContext(t *testing.T) 
 
 			require.ErrorIs(t, err, context.Canceled,
 				"pre-canceled ctx must surface as context.Canceled")
-			assert.Less(t, dur, 50*time.Millisecond,
+			assert.Less(t, dur, cancelAbortBudget,
 				"cancellation must abort promptly, got %v", dur)
 		})
 	}
 }
+
+// cancelAbortBudget bounds how long Generate may take on a pre-canceled
+// context. The correctness assertion in these tests is the context.Canceled
+// error; this bound is the secondary guard that catches a regression where ctx
+// is dropped and the generator runs the whole document to completion.
+//
+// Race instrumentation multiplies the cost of the work being bounded, so the
+// budget is widened under -race. It stays far below the time a full 10,000
+// element generation takes, which is what the bound exists to distinguish.
+var cancelAbortBudget = func() time.Duration {
+	if racedetect.Enabled {
+		return 2 * time.Second
+	}
+
+	return 50 * time.Millisecond
+}()

--- a/internal/converter/markdown_formatters_test.go
+++ b/internal/converter/markdown_formatters_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	builderPkg "github.com/EvilBit-Labs/opnDossier/internal/converter/builder"
+	"github.com/EvilBit-Labs/opnDossier/internal/testing/racedetect"
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
 
@@ -379,6 +380,14 @@ func generateLargeBenchmarkData(b *testing.B) *common.CommonDevice {
 func TestPerformanceBaselines(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping performance baseline tests in short mode")
+	}
+
+	// These are latency baselines, so running them under race instrumentation
+	// measures the instrumentation. Empirically the sub-millisecond thresholds
+	// below fail every run under -race on a loaded machine while passing every
+	// run without it, which is what kept the race detector out of CI.
+	if racedetect.Enabled {
+		t.Skip("Skipping performance baseline tests under -race: instrumentation dominates the measurement")
 	}
 
 	// Load test data

--- a/internal/testing/racedetect/doc.go
+++ b/internal/testing/racedetect/doc.go
@@ -1,0 +1,8 @@
+// Package racedetect reports whether the binary was built with the Go race
+// detector enabled.
+//
+// Tests use it to skip or widen wall-clock assertions. Race instrumentation
+// adds several times the normal execution cost, so a latency bound calibrated
+// without it measures the instrumentation rather than the code under test and
+// fails on a loaded machine such as a shared CI runner. See GOTCHAS.md §1.2.
+package racedetect

--- a/internal/testing/racedetect/doc.go
+++ b/internal/testing/racedetect/doc.go
@@ -4,5 +4,5 @@
 // Tests use it to skip or widen wall-clock assertions. Race instrumentation
 // adds several times the normal execution cost, so a latency bound calibrated
 // without it measures the instrumentation rather than the code under test and
-// fails on a loaded machine such as a shared CI runner. See GOTCHAS.md §1.2.
+// fails on a loaded machine such as a shared CI runner. See GOTCHAS.md §1.6.
 package racedetect

--- a/internal/testing/racedetect/racedetect.go
+++ b/internal/testing/racedetect/racedetect.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package racedetect
+
+// Enabled reports whether this build has the race detector compiled in.
+const Enabled = false

--- a/internal/testing/racedetect/racedetect_race.go
+++ b/internal/testing/racedetect/racedetect_race.go
@@ -1,0 +1,6 @@
+//go:build race
+
+package racedetect
+
+// Enabled reports whether this build has the race detector compiled in.
+const Enabled = true


### PR DESCRIPTION
## Summary

`GOTCHAS.md` §1.1 and `CONTRIBUTING.md` both state the race detector "cannot be hosted reliably on GitHub Actions runners", and no workflow runs it. That is correct about the symptom, but the cause is a handful of wall-clock assertions rather than the detector, and it is fixable.

Measured on a 32-core machine, `TestPerformanceBaselines`:

| Condition | Result |
| --- | --- |
| `-race`, idle | 10/10 pass |
| `-race`, all cores saturated | **0/10 pass** |
| no race, all cores saturated | 10/10 pass |

Race instrumentation multiplies execution cost, and that test asserts sub-millisecond latencies (`<200us`, `<500us`, `<3ms`). Under instrumentation on a contended machine those thresholds measure the instrumentation, which is exactly what a shared CI runner provides. `TestHybridGenerator_Generate_RespectsCanceledContext` and its `GenerateToWriter` counterpart failed the same way against their 50ms bound.

With those two cases handled, the full race suite passes **6/6 under the same saturating load** that previously failed every run, and the detector now runs in CI.

## Approach

`internal/testing/racedetect` exposes a build-tagged `Enabled` constant, and each timing assertion is handled according to what it is actually measuring:

- `TestPerformanceBaselines` **skips** under `-race`. It is a latency baseline, so running it under instrumentation measures the wrong thing. It already skipped under `-short` for the same class of reason.
- The `build_test.go` tests **skip** under `-race`. They build and run the binary as a subprocess, and a child produced by plain `go build` carries no race instrumentation, so the detector cannot observe it. In the race job the build cache holds only race-flavored artifacts, so that child compiles cold: 26s measured on 2 CPUs against the tests' 30s deadlines, which is why the job's first three runs all failed in this file at exactly 30s. The regular test jobs still run these on every push.
- The two cancellation tests take their bound from `cancelAbortBudget`, which widens to 2s under `-race`. Their correctness assertion is the `context.Canceled` error; the bound is a coarse guard against `ctx` being dropped and the generator running a 10,000 element document to completion. 2s still separates those two outcomes by a wide margin.

The job deliberately does **not** pass `-short`. That would have been the smaller change and it does make the suite pass, but `-short` skips `TestReport_ThreadSafetyStress`, `TestCoreProcessor_ConcurrentSafety` and the `internal/pool` concurrency tests, which are the tests most worth running under the detector. Verified those still execute in the race job:

```console
$ go test -race -v ./internal/pool/ ./internal/processor/ -run "Stress|ThreadSafety|Concurren"
--- PASS: TestConcurrentStringBuilderAccess (0.09s)
--- PASS: TestConcurrentBytesBufferAccess (0.09s)
--- PASS: TestCoreProcessor_ConcurrentSafety (0.00s)
--- PASS: TestReport_ThreadSafetyStress (1.82s)
```

## Acceptance criteria

- [x] New `Race Detector` job in `.github/workflows/ci.yml` running `just test-race`, so the CI command stays versioned in the repo like the others.
- [x] Full `-race` suite passes 6/6 under saturating load.
- [x] Concurrency and stress tests still run under the detector; no coverage traded away.
- [x] `TestPerformanceBaselines` skips under `-race` and still runs and passes without it.
- [x] Lint clean under both build variants: `golangci-lint run ./...` and `golangci-lint run --build-tags=race ./...`.
- [x] `gosec` unchanged at 11 findings, matching `main`.
- [x] `GOTCHAS.md` §1.1 and `CONTRIBUTING.md` no longer say the opposite of what CI does.
- [x] `Race Detector` registered in `.mergify.yml` alongside the other full-CI checks, so a red race job blocks the merge instead of being advisory.

## Out of scope

- Widening the Windows job beyond `just ci-smoke`. It fails today for an unrelated reason: `nao1215/markdown` emits CRLF on Windows while the golden fixtures are LF. That is fixed separately in #754, which also widens the job.
- The `-race` timeout stays at the existing `just test-race` value of 10m.

## Test plan

- [x] `just check`: all hooks pass
- [x] `just format-check`: clean
- [x] `just lint`: 0 issues
- [x] `golangci-lint run --build-tags=race ./...`: 0 issues
- [x] `go test ./...`: pass
- [x] `go test -tags=integration ./...`: pass
- [x] `just test-race`: pass, including 6 consecutive runs under saturating CPU load
- [x] `gosec ./...`: 11 findings, same as `main`

New documentation: `GOTCHAS.md` §1.6 records the rule, so the next timing assertion added to the suite has to decide what it does under the detector rather than rediscovering this. It takes the next free number rather than slotting in at 1.2, because section numbers are cited from code and config here and renumbering the existing entries would have silently repointed live references (`internal/converter/enrichment_test.go` cites 1.4, and a `docs/solutions` writeup cites 1.3 and 1.4).

## AI disclosure

Used Claude Code (`claude-opus-5`) for the race detector CI job and the handling of the wall-clock assertions that blocked it. All code reviewed locally and via CI before push. Followed process per [`AI_POLICY.md`](../blob/main/AI_POLICY.md).

## Refs

- No existing issue.
- `GOTCHAS.md` §1.1 and `CONTRIBUTING.md` "Git Hooks" carried the previous decision; both are updated here.
- #754 fixes the CRLF mismatch noted under Out of scope and widens the Windows job.




