### PR TITLE
ci: stop running the race detector on GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,35 +92,6 @@ jobs:
         run: go test -tags=integration -v -timeout 5m ./...
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Race Detector
-  #
-  # Previously excluded because the suite could not survive it on a shared
-  # runner: TestPerformanceBaselines asserts sub-millisecond latencies, and
-  # race instrumentation made those fail every run under load while passing
-  # every run without it. Those assertions now skip under -race and the
-  # cancellation bounds scale with it, so the detector runs the suite here.
-  # Tests that build and run the binary as a subprocess also skip: the child
-  # is compiled without -race, so the detector cannot observe it, and the
-  # cold cross-flavor build alone overruns their 30-second budgets.
-  # Concurrency-sensitive tests are NOT skipped; -short is deliberately
-  # not used, since it would drop the stress tests this job exists to cover.
-  # ─────────────────────────────────────────────────────────────────────────
-  race:
-    name: Race Detector
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          install: true
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run tests with race detector
-        run: just test-race
-
-  # ─────────────────────────────────────────────────────────────────────────
   # Coverage - Generate and upload coverage report
   # ─────────────────────────────────────────────────────────────────────────
   coverage:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,7 +41,6 @@ queue_rules:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
-      - check-success = Race Detector
 
   # ─────────────────────────────────────────────────────────────────────────
   # 4. default — manually enqueued by maintainers, full CI
@@ -57,7 +56,6 @@ queue_rules:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
-      - check-success = Race Detector
 
 pull_request_rules:
   # ─────────────────────────────────────────────────────────────────────────
@@ -133,7 +131,6 @@ merge_protections:
       - "check-success = Test (windows-latest, stable)"
       - check-success = Integration Tests
       - check-success = Coverage
-      - check-success = Race Detector
 
   # ─────────────────────────────────────────────────────────────────────────
   # 3. Lint-only for bots with workflow-only changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ just ci-check
 
 It is intentionally **not** wired to a git hook. A prior iteration added a pre-push `just ci-check` hook, but non-interactive push clients (including Copilot agents) could not recover when the hook failed and discarded the session. Developer discipline replaces automation here — CI runs the subset it can host, and `just ci-check` remains the locally-runnable gate.
 
-**Race detector note.** `test-race` (the Go race detector) runs in CI as its own job and locally via `just test-race` or `just ci-check`. It was previously local-only because the suite's wall-clock assertions failed under instrumentation on a shared runner; those now skip or scale under `-race` (GOTCHAS §1.6). If you add a timing bound to a test, decide what it does under the detector before pushing.
+**Race detector note.** `test-race` (the Go race detector) is **local-only** — run it via `just test-race` or `just ci-check`. It is deliberately not a CI job: GitHub's shared runners cannot host the instrumented suite reliably, and the job failed without producing a usable signal (GOTCHAS § 1.7). That makes your local run the only place a data race gets caught, so run `just ci-check` before you push. If you add a timing bound to a test, decide what it does under the detector first (GOTCHAS § 1.6).
 
 ### Known Gotchas
 

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -61,6 +61,7 @@ GitHub's shared runners cannot host it reliably. The instrumented suite is slow 
 - **Where the protection actually comes from:** the `forbidigo` rule in `.golangci.yml` forbids `t.Parallel()` in `cmd/` at lint time (§ 1.1), and `just ci-check` runs the detector before you push.
 - **If you re-add the job, you must also re-add its Mergify gates.** `.mergify.yml` lists `check-success` conditions in three places (the dependabot queue, the `default` queue, and the `Full CI must pass` rule). Removing a job without removing its gates deadlocks every PR on a check that never reports; adding a job without adding its gates means nothing enforces it.
 - **The `-race` accommodations in the test suite stay.** `internal/testing/racedetect.Enabled` and the skips it drives (§ 1.6) exist for the local run and are still load-bearing.
+- **The PR that removes a gated check cannot pass its own gate.** Mergify evaluates `.mergify.yml` from the **base** branch, so a PR deleting a job is still judged against `main`'s copy, which still requires it — `Full CI must pass` sits at "Waiting checks: `<job>`" indefinitely. This is not a misconfiguration and cannot be fixed from inside the PR; a maintainer merges it manually, and every PR afterwards uses the new config. The repo already routes workflow changes this way: the `Auto-queue` protection excludes any PR touching `.github/workflows/`.
 
 ## 2. Plugin Architecture
 

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -11,7 +11,7 @@ The `cmd/` package uses package-level global variables for CLI flags (required b
 - **Problem:** Concurrent tests modifying `sharedDeviceType`, `sharedAuditMode`, or the `rootCmd` flag set will cause non-deterministic data races.
 - **Symptom:** `just test-race` fails with "DATA RACE" reports in the `cmd` package.
 - **Solution:** Remove `t.Parallel()` from the parent test and all subtests that interact with global flags. Use `t.Cleanup()` to restore original global values after the test.
-- **Enforcement:** The `.golangci.yml` `forbidigo` rule forbids `t.Parallel()` anywhere in `cmd/` — catches the regression at lint time. The race detector runs in CI (the `Race Detector` job in `.github/workflows/ci.yml`) and locally via `just test-race` (or `just ci-check`). A prior pre-push `just ci-check` hook broke non-interactive push clients, so the full gate is still not wired to a git hook. See [CONTRIBUTING.md § Git Hooks](CONTRIBUTING.md#git-hooks) for the current setup.
+- **Enforcement:** The `.golangci.yml` `forbidigo` rule forbids `t.Parallel()` anywhere in `cmd/` — catches the regression at lint time, which is the only automated gate for this class. The race detector is **local-only**, via `just test-race` (or `just ci-check`); it is deliberately not a CI job — see § 1.7. A prior pre-push `just ci-check` hook broke non-interactive push clients, so the full gate is still not wired to a git hook. See [CONTRIBUTING.md § Git Hooks](CONTRIBUTING.md#git-hooks) for the current setup.
 
 ### 1.2 Race Detector Collateral
 
@@ -45,12 +45,22 @@ The `.golangci.yml` `gocognit` linter is configured to fail at cognitive complex
 
 ### 1.6 Wall-Clock Assertions and `-race`
 
-Race instrumentation multiplies execution cost, so a latency assertion calibrated without it measures the instrumentation. On a loaded machine `TestPerformanceBaselines` failed 10 of 10 runs under `-race` and passed 10 of 10 without it, which is why the detector was previously kept out of CI.
+Race instrumentation multiplies execution cost, so a latency assertion calibrated without it measures the instrumentation. On a loaded machine `TestPerformanceBaselines` failed 10 of 10 runs under `-race` and passed 10 of 10 without it — one of the reasons the detector is local-only (§ 1.7).
 
 - **Rule:** never add a wall-clock upper bound to a test without deciding what it does under `-race`.
 - **Pattern:** `internal/testing/racedetect.Enabled` is a build-tagged constant. Skip the assertion when the test is a latency baseline (`TestPerformanceBaselines`), or scale the bound when the bound is a coarse guard rather than a measurement (`cancelAbortBudget` in `internal/converter`, which only needs to tell "aborted" apart from "generated the whole document").
 - **Subprocess builds:** a test that shells out to `go build` gets no benefit from a `-race` run (the child is not instrumented) and pays for it twice: the build cache holds only race-flavored artifacts, so the child compiles cold, and a deadline calibrated against a warm cache kills it. `build_test.go` skips under `racedetect.Enabled` for exactly this reason.
 - **Do not** reach for `-short` to dodge this. It also skips the stress and thread-safety tests, which are the ones most worth running under the detector.
+
+### 1.7 The Race Detector Is Local-Only, Deliberately
+
+`just test-race` runs the detector locally and is part of `just ci-check`. It is **not** a CI job, and adding one back is a regression, not an improvement.
+
+GitHub's shared runners cannot host it reliably. The instrumented suite is slow and contended enough that the job fails without producing a usable signal — the last attempt exited non-zero after every one of the ~40 packages reported `ok`, with no data race, no failing test, and no error text anywhere in the log, then passed on a retry with no code change. A gate that red-lights a clean tree and greens a rerun teaches contributors to re-run it rather than to read it, which is worse than not having it.
+
+- **Where the protection actually comes from:** the `forbidigo` rule in `.golangci.yml` forbids `t.Parallel()` in `cmd/` at lint time (§ 1.1), and `just ci-check` runs the detector before you push.
+- **If you re-add the job, you must also re-add its Mergify gates.** `.mergify.yml` lists `check-success` conditions in three places (the dependabot queue, the `default` queue, and the `Full CI must pass` rule). Removing a job without removing its gates deadlocks every PR on a check that never reports; adding a job without adding its gates means nothing enforces it.
+- **The `-race` accommodations in the test suite stay.** `internal/testing/racedetect.Enabled` and the skips it drives (§ 1.6) exist for the local run and are still load-bearing.
 
 ## 2. Plugin Architecture
 


### PR DESCRIPTION
## What changed

Removes the `Race Detector` CI job and the three Mergify gates that require it.

- `.github/workflows/ci.yml` — the `race` job is deleted. Nothing else depended on it; it only had `needs: lint`, and no job needed it in turn.
- `.mergify.yml` — `check-success = Race Detector` is removed from all three rules that listed it: the dependabot queue, the `default` queue, and `Full CI must pass`.
- `GOTCHAS.md` — new § 1.7 records the decision and why, so the job is not re-added by someone reading § 1.1 and noticing the gap. § 1.6's closing line was stale in the other direction and is corrected.
- `CONTRIBUTING.md` — the race-detector note said the job runs in CI; it now says the local run is the only place a data race gets caught.

**The Mergify change is load-bearing, not tidy-up.** `Mergify Merge Protections` is the only required status check in the `Main` ruleset. Removing the job while leaving the gates would leave every PR waiting indefinitely on a check that never reports.

## Why

GitHub's shared runners cannot host the instrumented suite reliably. The most recent run exited non-zero after every one of the ~40 packages reported `ok` — no data race, no failing test, no error text anywhere in the log — and then passed on a retry against the same commit with no code change.

A gate that red-lights a clean tree and greens on a rerun does not carry signal. It trains contributors to re-run it rather than read it, which is worse than not having it, because it also erodes trust in the checks that *are* meaningful.

This restores the project's prior standing position rather than establishing a new one.

## What is deliberately unchanged

- `just test-race` and its inclusion in `just ci-check` — the detector still runs before a push.
- The `racedetect` build-tagged skips (`internal/testing/racedetect.Enabled`) and the assertions that scale under `-race`. Those exist for the local run and remain load-bearing; GOTCHAS § 1.6 still applies when adding a timing bound.
- The `forbidigo` rule forbidding `t.Parallel()` in `cmd/`. That is the lint-time gate for the regression class this most protects, it runs in CI, and it is untouched.

## How it was verified

```console
$ mise exec -- pre-commit run --files GOTCHAS.md CONTRIBUTING.md .mergify.yml .github/workflows/ci.yml
$ grep -o 'check-success = [^"]*' .mergify.yml | sort -u
```

`actionlint` and the YAML checks pass via pre-commit. Every remaining Mergify `check-success` context was cross-checked against a job name still present in `ci.yml` — Lint, Build, the three `Test (...)` matrix legs, Integration Tests, and Coverage all resolve; no gate is left pointing at a job that no longer exists.

## AI disclosure

Used Claude Code (`Claude Opus 5 (1M context)`) to make the config and documentation edits in this branch. All changes reviewed locally and via CI before push. Followed process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
