### PR TITLE
refactor(sanitizer): remove the unreachable domain mapper

### DIFF
--- a/internal/sanitizer/mapper.go
+++ b/internal/sanitizer/mapper.go
@@ -20,7 +20,6 @@ type Mapper struct {
 	privateIPCounter   int
 	hostnameCounter    int
 	usernameCounter    int
-	domainCounter      int
 	macCounter         int
 	emailCounter       int
 	authServerCounters map[string]int
@@ -29,7 +28,6 @@ type Mapper struct {
 	ipMappings         map[string]string
 	hostnameMappings   map[string]string
 	usernameMappings   map[string]string
-	domainMappings     map[string]string
 	macMappings        map[string]string
 	emailMappings      map[string]string
 	authServerMappings map[string]map[string]string
@@ -51,7 +49,6 @@ type MappingCategories struct {
 	IPAddresses  map[string]string   `json:"ip_addresses,omitempty"`
 	Hostnames    map[string]string   `json:"hostnames,omitempty"`
 	Usernames    map[string]string   `json:"usernames,omitempty"`
-	Domains      map[string]string   `json:"domains,omitempty"`
 	MACAddresses map[string]string   `json:"mac_addresses,omitempty"`
 	Emails       map[string]string   `json:"emails,omitempty"`
 	AuthServer   *AuthServerMappings `json:"authserver,omitempty"`
@@ -80,7 +77,6 @@ func NewMapper() *Mapper {
 		ipMappings:         make(map[string]string),
 		hostnameMappings:   make(map[string]string),
 		usernameMappings:   make(map[string]string),
-		domainMappings:     make(map[string]string),
 		macMappings:        make(map[string]string),
 		emailMappings:      make(map[string]string),
 		authServerCounters: make(map[string]int),
@@ -169,30 +165,6 @@ func (m *Mapper) MapUsername(original string) string {
 	return replacement
 }
 
-// Domain redaction constants.
-const (
-	defaultRedactedDomain = "example.com"
-)
-
-// MapDomain returns a consistent replacement for a domain name.
-func (m *Mapper) MapDomain(original string) string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if replacement, exists := m.domainMappings[original]; exists {
-		return replacement
-	}
-
-	m.domainCounter++
-	if m.domainCounter == 1 {
-		m.domainMappings[original] = defaultRedactedDomain
-		return defaultRedactedDomain
-	}
-	replacement := fmt.Sprintf("example%d.com", m.domainCounter)
-	m.domainMappings[original] = replacement
-	return replacement
-}
-
 // MapMAC returns a consistent replacement for a MAC address.
 func (m *Mapper) MapMAC(original string) string {
 	m.mu.Lock()
@@ -272,7 +244,6 @@ func (m *Mapper) GenerateReport(mode string) *MappingReport {
 			IPAddresses:  copyMap(m.ipMappings),
 			Hostnames:    copyMap(m.hostnameMappings),
 			Usernames:    copyMap(m.usernameMappings),
-			Domains:      copyMap(m.domainMappings),
 			MACAddresses: copyMap(m.macMappings),
 			Emails:       copyMap(m.emailMappings),
 			AuthServer:   authServerReport(m.authServerMappings),
@@ -296,7 +267,6 @@ func (m *Mapper) Reset() {
 	m.privateIPCounter = 0
 	m.hostnameCounter = 0
 	m.usernameCounter = 0
-	m.domainCounter = 0
 	m.macCounter = 0
 	m.emailCounter = 0
 	m.authServerCounters = make(map[string]int)
@@ -304,7 +274,6 @@ func (m *Mapper) Reset() {
 	m.ipMappings = make(map[string]string)
 	m.hostnameMappings = make(map[string]string)
 	m.usernameMappings = make(map[string]string)
-	m.domainMappings = make(map[string]string)
 	m.macMappings = make(map[string]string)
 	m.emailMappings = make(map[string]string)
 	m.authServerMappings = make(map[string]map[string]string)

--- a/internal/sanitizer/mapper_test.go
+++ b/internal/sanitizer/mapper_test.go
@@ -45,9 +45,6 @@ func TestNewMapper(t *testing.T) {
 	if m.usernameMappings == nil {
 		t.Error("usernameMappings map not initialized")
 	}
-	if m.domainMappings == nil {
-		t.Error("domainMappings map not initialized")
-	}
 	if m.macMappings == nil {
 		t.Error("macMappings map not initialized")
 	}
@@ -215,28 +212,6 @@ func TestMapUsername(t *testing.T) {
 	}
 }
 
-func TestMapDomain(t *testing.T) {
-	m := NewMapper()
-
-	// First domain gets example.com
-	result1 := m.MapDomain("mycompany.com")
-	if result1 != "example.com" {
-		t.Errorf("MapDomain first = %q, want %q", result1, "example.com")
-	}
-
-	// Same domain should return same mapping
-	result2 := m.MapDomain("mycompany.com")
-	if result2 != result1 {
-		t.Errorf("MapDomain second call = %q, want %q", result2, result1)
-	}
-
-	// Second unique domain
-	result3 := m.MapDomain("othercompany.org")
-	if result3 != "example2.com" {
-		t.Errorf("MapDomain second = %q, want %q", result3, "example2.com")
-	}
-}
-
 func TestMapMAC(t *testing.T) {
 	m := NewMapper()
 
@@ -380,7 +355,6 @@ func TestGenerateReport(t *testing.T) {
 	m.MapPrivateIP("192.168.1.1")
 	m.MapHostname("firewall.example.com")
 	m.MapUsername("admin")
-	m.MapDomain("mycompany.com")
 	m.MapMAC("00:11:22:33:44:55")
 	m.MapEmail("admin@mycompany.com")
 	m.MapAuthServerValue(authServerFieldHost, "ldap.example.com")


### PR DESCRIPTION
## What

Removes `MapDomain` from `internal/sanitizer`, along with its counter, its map, the `defaultRedactedDomain` constant, the `Domains` field on `MappingCategories`, and the tests that covered them.

57 lines out, nothing in.

## Why

`MapDomain` has no callers. Nothing in the repository invokes it, tests included, so `domainMappings` is never written and the `domains` category is absent from every mapping file the tool has ever produced.

Fields named `domain` are already handled, just not by this function. The `hostname` rule in `rules.go` carries `"domain"` in its `FieldPatterns` list alongside `"hostname"`, so those values go through `MapHostname`. A run against a config containing `<domain>corp.internal</domain>` maps it to `host-002.example.com`, not to the `example.com` the domain mapper would have produced.

This is the same condition #777 addressed at package scale, one function smaller.

## Output is unchanged

The `Domains` JSON tag carried `omitempty` and the map was always empty, so the key never appeared in output. Sanitizing the same config on `main` and on this branch produces:

- byte-identical mapping JSON once the run timestamp is excluded
- byte-identical sanitized XML

Emitted categories before and after: `ip_addresses`, `hostnames`, `usernames`, `mac_addresses`, `emails`.

## Verification

```console
$ mise exec -- go build ./... && mise exec -- go vet ./...
$ mise exec -- golangci-lint run ./...
0 issues.
$ mise exec -- go test -count=1 ./...
0 failures
```

Removing the constant left an empty `const ()` block, which `gocritic` flagged as `emptyDecl`; that is removed too.

## Origin

Found while correcting the mapping-file example in #752, where the documentation described a `domains` category that cannot occur. I noted there that the dead function was a code question rather than a docs one and left it out of that PR. This is that follow-up.

## AI disclosure

Used Claude Code (Claude Opus 5) for the code and documentation edits in this branch. All changes reviewed locally; full build, vet, lint, and test suite run before push. Followed process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
