### PR TITLE
fix(sanitizer): accept configs that declare a charset

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -384,6 +384,16 @@ A fresh `NewRuleEngine` creates a fresh `NewMapper()` — mappings are determini
 - **Why warn instead of fix:** Supporting struct-valued maps via reflection requires reconstructing each element in place (read → recurse into a copy → `SetMapIndex` with the mutated copy). That work is scheduled under todo #151 (tag-based redaction) which will subsume this gap by annotating sensitive fields directly and driving redaction from tags instead of field-name heuristics. The warning is the bridge until #151 lands.
 - **Regression tests:** `TestSanitizeStruct_MapStructValues_WarnsAndSkips` and `TestSanitizeStruct_MapStructValues_NilLoggerNoPanic` in `internal/sanitizer/sanitizer_reflect_test.go` pin both the warning path and the nil-logger nil-safety invariant. If a future enhancement starts handling struct-valued maps, those tests must be updated (or replaced) to reflect the new behavior — do not delete them blind.
 
+### 14.5 The Sanitizer Builds Its Own Decoder
+
+`sanitizeXMLContent` constructs an `xml.Decoder` directly rather than going through `parser.NewSecureXMLDecoder`, because it needs `Strict = false` and token-level access the parsers do not. That means **every hardening the parsers get has to be repeated here by hand**, and one was missing: with no `CharsetReader`, `encoding/xml` refuses any declaration other than UTF-8 with `encoding %q declared but Decoder.CharsetReader is nil`.
+
+Real OPNsense writes `<?xml version='1.0' encoding='us-ascii'?>`, so `opndossier sanitize` failed outright on its most common input, and on `testdata/sample.config.2.xml` and `sample.config.4.xml`. The failure was easy to miss because the verification loop in CONTRIBUTING pipes stderr to `/dev/null`, so a crashed run and a clean run both show zero unredacted lines.
+
+- **When you add hardening to `pkg/parser/xmlutil.go`, check whether `sanitizeXMLContent` needs it too.** The two decoders are independent.
+- **The output is always UTF-8.** `CharsetReader` decodes the input, so `writeXMLDeclaration` rewrites a non-UTF-8 declaration to `encoding="UTF-8"`; copying the original would label the file with an encoding it is not in. A UTF-8 or bare declaration is copied byte for byte so existing output does not shift.
+- **Check exit codes, not just output, when testing the CLI.** `sanitize ... 2>/dev/null | grep` hides a total failure as an empty result.
+
 ## 15. Liberal Boolean and Integer Parsing
 
 ### 15.0 `BoolFlag` vs `FlexBool` vs `FlexInt` vs strict `int`/`bool`

--- a/internal/sanitizer/charset_test.go
+++ b/internal/sanitizer/charset_test.go
@@ -1,0 +1,169 @@
+package sanitizer
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// assertReparses fails the test when s is not a well-formed XML document.
+// The sanitizer's contract is that a config.xml in produces a config.xml out.
+func assertReparses(t *testing.T, s string) {
+	t.Helper()
+
+	decoder := xml.NewDecoder(strings.NewReader(s))
+	for {
+		_, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("sanitized output is not well-formed XML: %v (output: %s)", err, s)
+		}
+	}
+}
+
+// TestSanitizeXML_AcceptsDeclaredCharsets guards a hard failure of the sanitize
+// command. sanitizeXMLContent built a decoder with no CharsetReader, so
+// encoding/xml refused any declaration other than UTF-8 with "encoding %q
+// declared but Decoder.CharsetReader is nil". A real OPNsense config.xml
+// declares us-ascii, and two of the fixtures in testdata/ do, so the flagship
+// "make this safe to share" command failed outright on its most common input.
+func TestSanitizeXML_AcceptsDeclaredCharsets(t *testing.T) {
+	t.Parallel()
+
+	body := `<opnsense><system><hostname>fw</hostname></system></opnsense>`
+
+	tests := []struct {
+		name string
+		decl string
+	}{
+		{"no declaration", ""},
+		{"utf-8", `<?xml version="1.0" encoding="UTF-8"?>`},
+		{"utf-8 single quoted", `<?xml version='1.0' encoding='UTF-8'?>`},
+		{"us-ascii", `<?xml version='1.0' encoding='us-ascii'?>`},
+		{"iso-8859-1", `<?xml version="1.0" encoding="ISO-8859-1"?>`},
+		{"windows-1252", `<?xml version="1.0" encoding="Windows-1252"?>`},
+		{"no encoding attribute", `<?xml version="1.0"?>`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewSanitizer(ModeMinimal)
+			var out bytes.Buffer
+			if err := s.SanitizeXML(strings.NewReader(tt.decl+body), &out); err != nil {
+				t.Fatalf("SanitizeXML() error = %v", err)
+			}
+
+			assertReparses(t, out.String())
+
+			if !strings.Contains(out.String(), "<hostname>") {
+				t.Errorf("document body was lost: %s", out.String())
+			}
+		})
+	}
+}
+
+// TestSanitizeXML_RelabelsNonUTF8Declaration checks that the emitted
+// declaration matches the bytes actually written. CharsetReader decodes the
+// input to UTF-8, so echoing the original "us-ascii" or "iso-8859-1" would
+// label the output with an encoding it is not in.
+func TestSanitizeXML_RelabelsNonUTF8Declaration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		decl     string
+		wantDecl string
+	}{
+		// Rewritten: the output is UTF-8, whatever the input declared.
+		{"us-ascii", `<?xml version='1.0' encoding='us-ascii'?>`, canonicalXMLDeclaration},
+		{"iso-8859-1", `<?xml version="1.0" encoding="ISO-8859-1"?>`, canonicalXMLDeclaration},
+		// Preserved byte for byte: already UTF-8, or no encoding named.
+		{"utf-8 double quoted", `<?xml version="1.0" encoding="UTF-8"?>`, `<?xml version="1.0" encoding="UTF-8"?>`},
+		{"utf-8 single quoted", `<?xml version='1.0' encoding='UTF-8'?>`, `<?xml version='1.0' encoding='UTF-8'?>`},
+		{"version only", `<?xml version="1.0"?>`, `<?xml version="1.0"?>`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := NewSanitizer(ModeMinimal)
+			var out bytes.Buffer
+			if err := s.SanitizeXML(strings.NewReader(tt.decl+`<opnsense><a>x</a></opnsense>`), &out); err != nil {
+				t.Fatalf("SanitizeXML() error = %v", err)
+			}
+
+			got, _, _ := strings.Cut(out.String(), "\n")
+			if got != tt.wantDecl {
+				t.Errorf("declaration = %q, want %q", got, tt.wantDecl)
+			}
+		})
+	}
+}
+
+// TestSanitizeXML_DecodesHighBytes asserts the charset table is applied rather
+// than the bytes being passed through. 0x93 and 0x94 are the Windows-1252 curly
+// quotes and are undefined in ISO-8859-1.
+func TestSanitizeXML_DecodesHighBytes(t *testing.T) {
+	t.Parallel()
+
+	var in bytes.Buffer
+	in.WriteString(`<?xml version="1.0" encoding="Windows-1252"?><opnsense><descr>caf`)
+	in.WriteByte(0xE9)
+	in.WriteByte(0x20)
+	in.WriteByte(0x93)
+	in.WriteString("crew")
+	in.WriteByte(0x94)
+	in.WriteString(`</descr></opnsense>`)
+
+	s := NewSanitizer(ModeMinimal)
+	var out bytes.Buffer
+	if err := s.SanitizeXML(bytes.NewReader(in.Bytes()), &out); err != nil {
+		t.Fatalf("SanitizeXML() error = %v", err)
+	}
+
+	result := out.String()
+	assertReparses(t, result)
+
+	if !strings.Contains(result, "caf\u00e9 \u201ccrew\u201d") {
+		t.Errorf("Windows-1252 high bytes were not decoded: %q", result)
+	}
+	if !strings.Contains(result, canonicalXMLDeclaration) {
+		t.Errorf("output still declares a non-UTF-8 charset: %q", result)
+	}
+}
+
+func TestDeclaresNonUTF8Charset(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		decl string
+		want bool
+	}{
+		{`<?xml version="1.0"?>`, false},
+		{`<?xml version="1.0" encoding="UTF-8"?>`, false},
+		{`<?xml version="1.0" encoding="utf-8"?>`, false},
+		{`<?xml version='1.0' encoding='utf8'?>`, false},
+		{`<?xml version='1.0' encoding='us-ascii'?>`, true},
+		{`<?xml version="1.0" encoding="ISO-8859-1"?>`, true},
+		{`<?xml version="1.0" encoding="Windows-1252"?>`, true},
+		{`<?xml version="1.0" encoding=""?>`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.decl, func(t *testing.T) {
+			t.Parallel()
+
+			if got := declaresNonUTF8Charset([]byte(tt.decl)); got != tt.want {
+				t.Errorf("declaresNonUTF8Charset(%q) = %v, want %v", tt.decl, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sanitizer/charset_test.go
+++ b/internal/sanitizer/charset_test.go
@@ -160,6 +160,19 @@ func TestDeclaresNonUTF8Charset(t *testing.T) {
 		{`<?xml version="1.0" encoding="ISO-8859-1"?>`, true},
 		{`<?xml version="1.0" encoding="Windows-1252"?>`, true},
 		{`<?xml version="1.0" encoding=""?>`, false},
+		// Whitespace around the "=" is legal XML but Go's decoder does not
+		// implement it, so it never transcodes these and the declaration must
+		// be copied rather than relabelled.
+		{`<?xml version="1.0" encoding= "ISO-8859-1"?>`, false},
+		{`<?xml version="1.0" encoding ="ISO-8859-1"?>`, false},
+		{"<?xml version=\"1.0\" encoding=\n\"ISO-8859-1\"?>", false},
+		{"<?xml version=\"1.0\" encoding\n=\"ISO-8859-1\"?>", false},
+		// Whitespace before the attribute name is fine: the decoder reads it.
+		{"<?xml version=\"1.0\"\n  encoding=\"ISO-8859-1\"?>", true},
+		// The decoder scans for the next "encoding=" that is followed by a
+		// quote, so the second attribute is the one that counts.
+		{`<?xml version="1.0" encoding=x encoding="ISO-8859-1"?>`, true},
+		{`<?xml version="1.0" encoding=broken?>`, false},
 	}
 
 	for _, tt := range tests {
@@ -168,6 +181,78 @@ func TestDeclaresNonUTF8Charset(t *testing.T) {
 
 			if got := declaresNonUTF8Charset([]byte(tt.decl)); got != tt.want {
 				t.Errorf("declaresNonUTF8Charset(%q) = %v, want %v", tt.decl, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeclaresNonUTF8Charset_AgreesWithDecoder pins the invariant the helper
+// exists to satisfy: the sanitizer must relabel a declaration exactly when the
+// decoder transcoded the body, and never otherwise. Disagreement in either
+// direction is a bug. Relabelling without transcoding rewrites a document that
+// was passed through untouched; transcoding without relabelling leaves the
+// output claiming an encoding it is not in.
+//
+// The two are checked against each other rather than against a fixed table
+// because the helper deliberately mirrors encoding/xml's own non-conformant
+// parsing of the encoding attribute.
+func TestDeclaresNonUTF8Charset_AgreesWithDecoder(t *testing.T) {
+	t.Parallel()
+
+	const body = `<o><h>fw</h></o>`
+
+	decls := []string{
+		`<?xml version="1.0" encoding="ISO-8859-1"?>`,
+		`<?xml version="1.0" encoding='ISO-8859-1'?>`,
+		"<?xml version=\"1.0\"\n  encoding=\"ISO-8859-1\"?>",
+		"<?xml version=\"1.0\"\tencoding=\"ISO-8859-1\"?>",
+		"<?xml version=\"1.0\"\r encoding=\"ISO-8859-1\"?>",
+		"<?xml version=\"1.0\" encoding=\n\"ISO-8859-1\"?>",
+		"<?xml version=\"1.0\" encoding=\r\"ISO-8859-1\"?>",
+		"<?xml version=\"1.0\" encoding\n=\"ISO-8859-1\"?>",
+		`<?xml version="1.0" encoding= "ISO-8859-1"?>`,
+		`<?xml version="1.0" encoding ="ISO-8859-1"?>`,
+		`<?xml version="1.0" encoding="UTF-8"?>`,
+		`<?xml version="1.0" encoding="UTF_8"?>`,
+		`<?xml version="1.0" encoding="ISO_8859_1"?>`,
+		`<?xml version="1.0" encoding="us-ascii"?>`,
+		`<?xml version="1.0"?>`,
+		`<?xml version="1.0" encoding=broken?>`,
+		`<?xml version="1.0" encoding=x encoding="ISO-8859-1"?>`,
+	}
+
+	for _, decl := range decls {
+		t.Run(decl, func(t *testing.T) {
+			t.Parallel()
+
+			var handed string
+
+			decoder := xml.NewDecoder(strings.NewReader(decl + body))
+			decoder.CharsetReader = func(charset string, input io.Reader) (io.Reader, error) {
+				handed = charset
+
+				return input, nil
+			}
+
+			for {
+				if _, err := decoder.Token(); err != nil {
+					break
+				}
+			}
+
+			// CharsetReader is called only for a declared charset the decoder
+			// recognized, and it passes UTF-8 bytes through untouched.
+			normalized := strings.ReplaceAll(strings.ToLower(handed), "_", "-")
+			transcoded := handed != "" && normalized != "utf-8" && normalized != "utf8"
+
+			if got := declaresNonUTF8Charset([]byte(decl)); got != transcoded {
+				t.Errorf(
+					"declaresNonUTF8Charset(%q) = %v, but the decoder transcoded = %v (charset handed to CharsetReader: %q)",
+					decl,
+					got,
+					transcoded,
+					handed,
+				)
 			}
 		})
 	}

--- a/internal/sanitizer/charset_test.go
+++ b/internal/sanitizer/charset_test.go
@@ -87,6 +87,9 @@ func TestSanitizeXML_RelabelsNonUTF8Declaration(t *testing.T) {
 		// Preserved byte for byte: already UTF-8, or no encoding named.
 		{"utf-8 double quoted", `<?xml version="1.0" encoding="UTF-8"?>`, `<?xml version="1.0" encoding="UTF-8"?>`},
 		{"utf-8 single quoted", `<?xml version='1.0' encoding='UTF-8'?>`, `<?xml version='1.0' encoding='UTF-8'?>`},
+		// CharsetReader normalizes "_" to "-", so this is UTF-8 and its bytes
+		// are passed through untouched; relabelling it would be wrong.
+		{"utf_8 underscore alias", `<?xml version="1.0" encoding="UTF_8"?>`, `<?xml version="1.0" encoding="UTF_8"?>`},
 		{"version only", `<?xml version="1.0"?>`, `<?xml version="1.0"?>`},
 	}
 
@@ -151,6 +154,8 @@ func TestDeclaresNonUTF8Charset(t *testing.T) {
 		{`<?xml version="1.0" encoding="UTF-8"?>`, false},
 		{`<?xml version="1.0" encoding="utf-8"?>`, false},
 		{`<?xml version='1.0' encoding='utf8'?>`, false},
+		{`<?xml version="1.0" encoding="UTF_8"?>`, false},
+		{`<?xml version="1.0" encoding="ISO_8859_1"?>`, true},
 		{`<?xml version='1.0' encoding='us-ascii'?>`, true},
 		{`<?xml version="1.0" encoding="ISO-8859-1"?>`, true},
 		{`<?xml version="1.0" encoding="Windows-1252"?>`, true},

--- a/internal/sanitizer/sanitizer.go
+++ b/internal/sanitizer/sanitizer.go
@@ -578,22 +578,35 @@ func writeXMLDeclaration(output *strings.Builder, data []byte) {
 // declaresNonUTF8Charset reports whether decl names an encoding that is not
 // UTF-8. A declaration with no encoding attribute is treated as UTF-8, the XML
 // default and what the sanitizer emits.
+//
+// The attribute is located the way encoding/xml locates it: the literal
+// "encoding=" followed immediately by a quote. XML 1.0 allows whitespace around
+// the "=" but Go's decoder does not, and a form the decoder does not recognize
+// is never transcoded, so treating it as a declared charset here would relabel
+// a document that was passed through untouched.
 func declaresNonUTF8Charset(decl []byte) bool {
 	lower := strings.ToLower(string(decl))
 
-	idx := strings.Index(lower, "encoding")
-	if idx < 0 {
-		return false
-	}
+	const attr = "encoding="
 
-	value := strings.TrimLeft(lower[idx+len("encoding"):], " \t=")
+	var (
+		value string
+		quote byte
+	)
 
-	var quote byte
-	if value != "" && (value[0] == '"' || value[0] == '\'') {
-		quote = value[0]
-		value = value[1:]
-	} else {
-		return false
+	for i := 0; ; {
+		k := strings.Index(lower[i:], attr)
+		if k < 0 {
+			return false
+		}
+
+		i += k + len(attr)
+		if i < len(lower) && (lower[i] == '"' || lower[i] == '\'') {
+			quote = lower[i]
+			value = lower[i+1:]
+
+			break
+		}
 	}
 
 	end := strings.IndexByte(value, quote)

--- a/internal/sanitizer/sanitizer.go
+++ b/internal/sanitizer/sanitizer.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/EvilBit-Labs/opnDossier/internal/logging"
 	"github.com/EvilBit-Labs/opnDossier/internal/pool"
+	"github.com/EvilBit-Labs/opnDossier/pkg/parser"
 )
 
 // Sanitizer orchestrates the redaction of sensitive data from OPNsense configuration.
@@ -127,6 +128,10 @@ func (s *Sanitizer) sanitizeXMLContent(data []byte) ([]byte, error) {
 	decoder.Strict = false
 	// Prevent XXE attacks by disabling entity expansion
 	decoder.Entity = map[string]string{}
+	// The same charset reader the device parsers use. Without it encoding/xml
+	// refuses any declaration other than UTF-8, so sanitize failed outright on
+	// a real OPNsense config.xml, which declares us-ascii.
+	decoder.CharsetReader = parser.CharsetReader
 
 	var output strings.Builder
 	output.Grow(len(data))
@@ -137,14 +142,7 @@ func (s *Sanitizer) sanitizeXMLContent(data []byte) ([]byte, error) {
 	// O(depth) string allocation per StartElement. See issue #148.
 	var pathStack []string
 
-	// Write XML declaration if present
-	if bytes.HasPrefix(bytes.TrimSpace(data), []byte("<?xml")) {
-		idx := bytes.Index(data, []byte("?>"))
-		if idx > 0 {
-			output.Write(data[:idx+2])
-			output.WriteString("\n")
-		}
-	}
+	writeXMLDeclaration(&output, data)
 
 	for {
 		token, err := decoder.Token()
@@ -543,6 +541,72 @@ func joinReflectPath(pathStack []string, sliceIdx int) string {
 		return last
 	}
 	return strings.Join(pathStack[:len(pathStack)-1], ".") + "." + last
+}
+
+// canonicalXMLDeclaration is the declaration written when the input's charset
+// had to be re-labelled.
+const canonicalXMLDeclaration = `<?xml version="1.0" encoding="UTF-8"?>`
+
+// writeXMLDeclaration emits the sanitized document's XML declaration.
+//
+// A declaration naming UTF-8, or naming no encoding at all, is copied verbatim
+// so output stays byte-identical for those inputs. Any other declared charset
+// is replaced with a canonical UTF-8 declaration, because CharsetReader has
+// already decoded the document and every byte written from here is UTF-8.
+// Copying the original would label the output with an encoding it is not in,
+// which re-parses as mojibake for anything outside ASCII.
+func writeXMLDeclaration(output *strings.Builder, data []byte) {
+	if !bytes.HasPrefix(bytes.TrimSpace(data), []byte("<?xml")) {
+		return
+	}
+
+	idx := bytes.Index(data, []byte("?>"))
+	if idx <= 0 {
+		return
+	}
+
+	decl := data[:idx+2]
+	if declaresNonUTF8Charset(decl) {
+		output.WriteString(canonicalXMLDeclaration)
+	} else {
+		output.Write(decl)
+	}
+
+	output.WriteString("\n")
+}
+
+// declaresNonUTF8Charset reports whether decl names an encoding that is not
+// UTF-8. A declaration with no encoding attribute is treated as UTF-8, the XML
+// default and what the sanitizer emits.
+func declaresNonUTF8Charset(decl []byte) bool {
+	lower := strings.ToLower(string(decl))
+
+	idx := strings.Index(lower, "encoding")
+	if idx < 0 {
+		return false
+	}
+
+	value := strings.TrimLeft(lower[idx+len("encoding"):], " \t=")
+
+	var quote byte
+	if value != "" && (value[0] == '"' || value[0] == '\'') {
+		quote = value[0]
+		value = value[1:]
+	} else {
+		return false
+	}
+
+	end := strings.IndexByte(value, quote)
+	if end < 0 {
+		return false
+	}
+
+	switch strings.TrimSpace(value[:end]) {
+	case "utf-8", "utf8", "":
+		return false
+	default:
+		return true
+	}
 }
 
 // escapeXMLText uses the stdlib xml.EscapeText to properly escape XML character data.

--- a/internal/sanitizer/sanitizer.go
+++ b/internal/sanitizer/sanitizer.go
@@ -601,7 +601,12 @@ func declaresNonUTF8Charset(decl []byte) bool {
 		return false
 	}
 
-	switch strings.TrimSpace(value[:end]) {
+	// Mirror CharsetReader's normalization: it treats UTF_8 as UTF-8 and passes
+	// those bytes through untouched, so relabelling that declaration would
+	// rewrite a document the sanitizer never transcoded.
+	charset := strings.ReplaceAll(strings.TrimSpace(value[:end]), "_", "-")
+
+	switch charset {
 	case "utf-8", "utf8", "":
 		return false
 	default:


### PR DESCRIPTION
## Summary

`opndossier sanitize` exits 1 and produces nothing on a real OPNsense `config.xml`:

```
Failed to sanitize configuration: sanitizing content: parsing xml:
xml: encoding "us-ascii" declared but Decoder.CharsetReader is nil.
```

OPNsense writes `<?xml version='1.0' encoding='us-ascii'?>`. Two of the shipped fixtures, `testdata/sample.config.2.xml` and `sample.config.4.xml`, declare it and fail today. ISO-8859-1 and Windows-1252 configs fail identically, and all three are listed as supported encodings on five documentation pages.

## What was wrong

`sanitizeXMLContent` builds its own `xml.Decoder` rather than going through `parser.NewSecureXMLDecoder`, because it needs `Strict = false` and token-level access the parsers do not. Every hardening the parsers get therefore has to be repeated by hand, and `CharsetReader` was missing.

Wiring in the shared `parser.CharsetReader` means the input is decoded, so every byte the sanitizer writes is UTF-8 whatever the input declared. The declaration is rewritten to UTF-8 when the input named something else; copying the original would label the file with an encoding it is not in, which re-parses as mojibake for anything outside ASCII. A UTF-8 or bare declaration is still copied byte for byte, so output for those inputs is unchanged.

The failure was easy to miss. The verification loop `CONTRIBUTING.md` gives for this command pipes stderr to `/dev/null`, so a crashed run and a clean run both print zero unredacted lines.

## Acceptance criteria

- [x] All 13 shipped fixtures sanitize with exit 0; two of them fail on `main`.
- [x] us-ascii, ISO-8859-1 and Windows-1252 inputs decode correctly and re-parse.
- [x] Output for UTF-8 and declaration-less inputs is byte-identical to before.
- [x] The emitted declaration matches the bytes actually written.
- [x] `GOTCHAS.md` §14.5 records that the sanitizer's decoder is independent of the parsers'.

## Out of scope

- Root-element detection, which has a separate and stricter charset reader. Swept in its own PR.
- The `Strict = false` setting, which is unchanged.

## Test plan

`TestSanitizeXML_DecodesHighBytes` asserts on bytes `0x93` and `0x94`, the Windows-1252 curly quotes, which are undefined in ISO-8859-1. It therefore fails if the bytes are passed through instead of decoded, not merely if the charset is rejected.

Verified the tests detect the defect rather than merely pass: with the `CharsetReader` assignment removed, `TestSanitizeXML_AcceptsDeclaredCharsets` fails on the us-ascii, iso-8859-1 and windows-1252 cases and `TestSanitizeXML_DecodesHighBytes` fails outright; restored, all pass.

| Check | Result |
| --- | --- |
| `go test ./...` | pass |
| `go test -tags=integration ./...` | pass |
| `go test -race ./...` | pass |
| `just lint` | 0 issues |
| 13 fixtures, `sanitize` exit code | 13/13 exit 0 (11/13 on `main`) |
| latin1 / cp1252 round trip through the CLI | decodes correctly, output re-parses |

## AI disclosure

Used Claude Code (`claude-opus-5`) for finding the charset failure and for the decoder and declaration changes. All code reviewed locally and via CI before push. Followed process per [`AI_POLICY.md`](../blob/main/AI_POLICY.md).

## Refs

- No existing issue.
