### PR TITLE
fix(diff): report the rule and user changes the diff was dropping

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -161,6 +161,37 @@ Most `Compare*` methods in `internal/diff/analyzer.go` have early-return guards 
 
 - **Exceptions:** `CompareFirewallRules` and `CompareUsers` intentionally omit section-level guards because per-item granularity is more useful for security-sensitive resources (individual rule additions/removals are reported separately).
 
+### 4.2 Rule and User Equality Helpers Must Cover Every Model Field
+
+`rulesEqual` and `usersEqual` in `internal/diff` decide whether a paired item is reported as modified. A field missing from either helper does not produce a weaker diff entry -- it produces **no entry at all**, silently.
+
+Both had drifted badly: `rulesEqual` compared 7 of `common.FirewallRule`'s 33 fields and `usersEqual` 5 of `common.User`'s 7. A diff stayed silent on a rule's direction being reversed, a rule becoming floating or quick, its gateway being redirected, its state type weakened, its logging turned off, and on a user's UID changing or an API credential being added, rotated or removed.
+
+- **When you add a field to `common.FirewallRule` or `common.User`, add it to the equality helper.** `TestRulesEqual_ComparesEveryFirewallRuleField` and `TestUsersEqual_ComparesEveryUserField` walk the struct reflectively and fail until you do.
+- **Only identity fields belong on the ignore list.** `UUID` and `Tracker` are excluded because `CompareFirewallRules` pairs on them; comparing them would mark every paired rule modified.
+
+### 4.3 Most Configs Have No Rule UUIDs
+
+`CompareFirewallRules` pairs rules by `UUID`, but **pfSense never writes one**, and neither do older OPNsense configs -- 10 of the 13 fixtures in `testdata/` have zero. The fallback used to compare only the rule *count*, so any content change that left the count intact was invisible: on `testdata/pfsense/config-2.6.x.xml`, flipping a rule from `pass` to `block` reported "No changes detected".
+
+`compareRulesWithoutUUID` now pairs in three passes -- by pfSense's `<tracker>`, then by exact content (which anchors the unchanged rules), then by remaining position. Whatever is left unpaired is a genuine addition or removal.
+
+- **Do not "simplify" this back to positional pairing.** The content-anchoring pass is what stops a rule inserted at the top from cascading into every rule below it reading as modified. `TestCompareFirewallRules_NoUUID_InsertionDoesNotCascade` guards it.
+- **Test new comparison logic against a UUID-less fixture.** A test built on `sample.config.6.xml` (which has UUIDs) exercises a different code path than one built on any pfSense fixture.
+- **Two known limits, pinned by `TestCompareFirewallRules_KnownLimits`.** Neither is a regression -- the count-only fallback reported nothing for either -- but both are sharp enough that a future change should decide about them rather than discover them:
+  - **A pure reorder produces no entry from content comparison.** That is by design -- order changes are the order detector's job, reached via `--detect-order`. Note that detector had the *same* UUID dependency: `extractRuleUUIDs` dropped every rule without a `<uuid>`, so `--detect-order` was a documented flag that silently found nothing on pfSense. It now keys on `ruleIdentity` (UUID, else `<tracker>`), and rules with neither stay out because a rule indistinguishable from its peers cannot be said to have moved.
+  - **Leftovers pair by similarity, not position.** Once the tracker and content passes have anchored what they can, the rest are scored against each other (`ruleSimilarity`) and matched best-first. Blind positional pairing misattributed edits: with `a, b, c(pass)` becoming `a, c(block)` it handed the surviving `c` to `b` and reported "b modified into c" plus "c removed". Weights are description 4, interface list 2, and one each for type, protocol, source, destination and port; `simMinScore` is 4, reachable by a matching description alone or by a matching interface list plus two other fields. Above `simMaxPairs` leftovers on either side the scoring is skipped and pairing falls back to positional, so a config where nothing anchors stays bounded.
+
+### 4.4 NAT Rules Were Compared By Count Only
+
+`CompareNAT` compared `len(old.OutboundRules) != len(newCfg.OutboundRules)` and the same for `InboundRules`, and nothing else. Every content change that left the counts intact was invisible: an outbound rule retargeted or moved to another interface, and -- worse -- a **port forward redirected to a different internal host**, which is about the most consequential NAT change there is.
+
+No NAT rule in any shipped fixture carries a `<uuid>`, not even in the OPNsense MVC configs that populate them on firewall rules, so this is the path every real config takes.
+
+- **Rules now pair via `itemPairer`** (`internal/diff/pairing.go`): identity, then exact content, then similarity, with a positional fallback. the same pairer the firewall rules use.
+- **`natRulesEqual` and `inboundNATRulesEqual` must cover every model field.** A field missing from either produces no diff entry at all, not a less detailed one. `TestNATRulesEqual_ComparesEveryField` and `TestInboundNATRulesEqual_ComparesEveryField` walk the structs reflectively and fail until you add it.
+- **Paths are `nat.inbound.rules[N]` and `nat.outbound.rules[N]`.** The `nat.inbound` prefix is load-bearing: the security scorer's `port-forward-change` pattern matches on it, so renaming the path silently drops the impact rating from every port-forward entry.
+
 ## 5. CLI Flag Wiring
 
 ### 5.1 Silent Flag Ignores

--- a/internal/diff/analyzer_completeness_test.go
+++ b/internal/diff/analyzer_completeness_test.go
@@ -1,0 +1,474 @@
+package diff
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// varyField gives v a value different from its zero, for the kinds the models
+// use. Returns false for kinds it has no probe for.
+func varyField(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("diff-probe")
+
+		return true
+	case reflect.Bool:
+		v.SetBool(!v.Bool())
+
+		return true
+	case reflect.Int:
+		v.SetInt(v.Int() + 1)
+
+		return true
+	case reflect.Slice:
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+
+		return true
+	case reflect.Pointer:
+		v.Set(reflect.New(v.Type().Elem()))
+
+		return true
+	case reflect.Struct:
+		for i := range v.NumField() {
+			f := v.Field(i)
+			if f.Kind() == reflect.String && f.CanSet() {
+				f.SetString("diff-probe")
+
+				return true
+			}
+		}
+
+		return false
+	default:
+		return false
+	}
+}
+
+// assertEqualityCoversEveryField varies each field of a zero value in turn and
+// asserts the equality helper notices, so a field added to the model without
+// being added to the helper fails here rather than silently disappearing from
+// every diff.
+func assertEqualityCoversEveryField[T any](t *testing.T, equal func(a, b T) bool, ignored map[string]string) {
+	t.Helper()
+
+	var zero T
+	typ := reflect.TypeOf(zero)
+	require.Equal(t, reflect.Struct, typ.Kind())
+
+	for i := range typ.NumField() {
+		name := typ.Field(i).Name
+
+		if reason, skip := ignored[name]; skip {
+			t.Logf("skipping %s: %s", name, reason)
+
+			continue
+		}
+
+		var a, b T
+		bv := reflect.ValueOf(&b).Elem().Field(i)
+
+		if !varyField(bv) {
+			t.Logf("skipping %s: no probe for kind %s", name, bv.Kind())
+
+			continue
+		}
+
+		assert.Falsef(t, equal(a, b),
+			"%s is not compared, so a change to it produces no diff entry; add it to the equality helper", name)
+	}
+}
+
+// TestRulesEqual_ComparesEveryFirewallRuleField guards the silent
+// under-reporting that motivated the rewrite: rulesEqual covered seven of the
+// model's thirty-three fields, so flipping a rule's direction, making it
+// floating, moving it to another gateway or turning its logging off all
+// produced "no changes detected".
+func TestRulesEqual_ComparesEveryFirewallRuleField(t *testing.T) {
+	t.Parallel()
+
+	assertEqualityCoversEveryField(t, rulesEqual, map[string]string{
+		"UUID":    "identity; CompareFirewallRules pairs on it",
+		"Tracker": "identity; compareRulesWithoutUUID pairs on it",
+	})
+}
+
+// TestUsersEqual_ComparesEveryUserField guards the same class on users, where
+// UID and APIKeys were omitted.
+func TestUsersEqual_ComparesEveryUserField(t *testing.T) {
+	t.Parallel()
+
+	assertEqualityCoversEveryField(t, usersEqual, nil)
+}
+
+// TestCompareFirewallRules_NoUUID_DetectsContentChange is the end-to-end half.
+// pfSense rules never carry a uuid element, and the fallback compared only the
+// rule COUNT, so a rule flipped from pass to block reported no changes at all.
+func TestCompareFirewallRules_NoUUID_DetectsContentChange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func([]common.FirewallRule)
+	}{
+		{"action flipped to block", func(r []common.FirewallRule) { r[0].Type = common.RuleTypeBlock }},
+		{"source widened to any", func(r []common.FirewallRule) {
+			r[0].Source = common.RuleEndpoint{Address: "any"}
+		}},
+		{"logging turned off", func(r []common.FirewallRule) { r[0].Log = false }},
+		{"direction reversed", func(r []common.FirewallRule) { r[0].Direction = common.DirectionOut }},
+		{"made floating", func(r []common.FirewallRule) { r[0].Floating = true }},
+		{"gateway redirected", func(r []common.FirewallRule) { r[0].Gateway = "GW_BACKUP" }},
+	}
+
+	newBase := func() []common.FirewallRule {
+		return []common.FirewallRule{
+			{
+				Type: common.RuleTypePass, Description: "web", Interfaces: []string{"wan"}, Log: true,
+				Source: common.RuleEndpoint{Address: "198.51.100.0/24"},
+			},
+			{
+				Type: common.RuleTypeBlock, Description: "deny", Interfaces: []string{"wan"}, Log: true,
+				Source: common.RuleEndpoint{Address: "any"},
+			},
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			old := newBase()
+			newCfg := newBase()
+			tt.mutate(newCfg)
+
+			changes := NewAnalyzer().CompareFirewallRules(old, newCfg)
+
+			require.NotEmpty(t, changes, "a rule content change must produce a diff entry")
+			assert.Len(t, changes, 1, "exactly the changed rule should be reported: %+v", changes)
+			assert.Equal(t, ChangeModified, changes[0].Type)
+		})
+	}
+}
+
+// TestCompareFirewallRules_NoUUID_UnchangedIsQuiet is the false-positive half.
+func TestCompareFirewallRules_NoUUID_UnchangedIsQuiet(t *testing.T) {
+	t.Parallel()
+
+	rules := []common.FirewallRule{
+		{Type: common.RuleTypePass, Description: "web", Interfaces: []string{"wan"}},
+		{Type: common.RuleTypeBlock, Description: "deny", Interfaces: []string{"wan"}},
+	}
+
+	assert.Empty(t, NewAnalyzer().CompareFirewallRules(rules, rules))
+}
+
+// TestCompareFirewallRules_NoUUID_InsertionDoesNotCascade checks that adding a
+// rule at the top reports one addition rather than marking every rule below it
+// as modified, which is what a purely positional pairing would do.
+func TestCompareFirewallRules_NoUUID_InsertionDoesNotCascade(t *testing.T) {
+	t.Parallel()
+
+	old := []common.FirewallRule{
+		{Type: common.RuleTypePass, Description: "web", Interfaces: []string{"wan"}},
+		{Type: common.RuleTypePass, Description: "dns", Interfaces: []string{"wan"}},
+		{Type: common.RuleTypeBlock, Description: "deny", Interfaces: []string{"wan"}},
+	}
+	newCfg := append([]common.FirewallRule{
+		{Type: common.RuleTypePass, Description: "ssh", Interfaces: []string{"wan"}},
+	}, old...)
+
+	changes := NewAnalyzer().CompareFirewallRules(old, newCfg)
+
+	require.Len(t, changes, 1, "only the inserted rule should be reported: %+v", changes)
+	assert.Equal(t, ChangeAdded, changes[0].Type)
+	assert.Contains(t, changes[0].Description, "ssh")
+}
+
+// TestCompareFirewallRules_PairsByTracker verifies the pfSense per-rule tracker
+// is used as identity, so a reordered rule is not reported as a remove plus an
+// add.
+func TestCompareFirewallRules_PairsByTracker(t *testing.T) {
+	t.Parallel()
+
+	old := []common.FirewallRule{
+		{Tracker: "1000000001", Type: common.RuleTypePass, Description: "web"},
+		{Tracker: "1000000002", Type: common.RuleTypePass, Description: "dns"},
+	}
+	newCfg := []common.FirewallRule{
+		{Tracker: "1000000002", Type: common.RuleTypePass, Description: "dns"},
+		{Tracker: "1000000001", Type: common.RuleTypeBlock, Description: "web"},
+	}
+
+	changes := NewAnalyzer().CompareFirewallRules(old, newCfg)
+
+	require.Len(t, changes, 1, "only the retyped rule should be reported: %+v", changes)
+	assert.Equal(t, ChangeModified, changes[0].Type)
+	assert.Contains(t, changes[0].Path, "1000000001")
+}
+
+// TestCompareUsers_DetectsAPIKeyAndUIDChanges covers the user fields that were
+// omitted from usersEqual.
+func TestCompareUsers_DetectsAPIKeyAndUIDChanges(t *testing.T) {
+	t.Parallel()
+
+	base := common.User{
+		Name: "alice", UID: "2000", Scope: "local",
+		APIKeys: []common.APIKey{{Key: "KEY-ORIGINAL", Secret: "SECRET-ORIGINAL"}},
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(common.User) common.User
+	}{
+		{"api key rotated", func(u common.User) common.User {
+			u.APIKeys = []common.APIKey{{Key: "KEY-ROTATED", Secret: "SECRET-ROTATED"}}
+
+			return u
+		}},
+		{"api key added", func(u common.User) common.User {
+			u.APIKeys = []common.APIKey{u.APIKeys[0], {Key: "KEY-SECOND"}}
+
+			return u
+		}},
+		{"api key removed", func(u common.User) common.User {
+			u.APIKeys = nil
+
+			return u
+		}},
+		{"uid changed", func(u common.User) common.User {
+			u.UID = "0"
+
+			return u
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			changes := NewAnalyzer().CompareUsers([]common.User{base}, []common.User{tt.mutate(base)})
+
+			require.Len(t, changes, 1, "change must be reported: %+v", changes)
+			assert.Equal(t, ChangeModified, changes[0].Type)
+		})
+	}
+}
+
+// TestCompareFirewallRules_KnownLimits documents two behaviours of the pairing
+// that are deliberate but sharp, so a future change to compareRulesWithoutUUID
+// has to decide about them rather than discover them.
+//
+// Neither is a regression: the previous implementation compared only the rule
+// count and reported nothing for either case.
+func TestCompareFirewallRules_KnownLimits(t *testing.T) {
+	t.Parallel()
+
+	mk := func(desc string, typ common.FirewallRuleType) common.FirewallRule {
+		return common.FirewallRule{Type: typ, Description: desc, Interfaces: []string{"wan"}}
+	}
+
+	t.Run("reordering alone is not reported by content comparison", func(t *testing.T) {
+		t.Parallel()
+
+		// pf is first-match, so moving a rule changes what the ruleset does.
+		// Content pairing matches every rule to its identical twin regardless of
+		// position, so a pure reorder produces no entry here. That is by design:
+		// order changes are the order detector's job, reached via --detect-order
+		// and covered by TestDetectOrder_WorksWithoutUUIDs.
+		old := []common.FirewallRule{
+			mk("a", common.RuleTypePass),
+			mk("b", common.RuleTypePass),
+			mk("c", common.RuleTypePass),
+		}
+		reordered := []common.FirewallRule{
+			mk("c", common.RuleTypePass),
+			mk("a", common.RuleTypePass),
+			mk("b", common.RuleTypePass),
+		}
+
+		assert.Empty(t, NewAnalyzer().CompareFirewallRules(old, reordered),
+			"content comparison does not report order; --detect-order does")
+	})
+}
+
+// TestDetectOrder_WorksWithoutUUIDs guards --detect-order for pfSense.
+//
+// extractRuleUUIDs dropped every rule without a <uuid>, so the ordered list it
+// handed DetectReorders was empty for any pfSense config and any older OPNsense
+// one. The flag is documented and accepted, and silently found nothing.
+//
+// Rules with no identity at all stay out: a rule indistinguishable from its
+// peers cannot be said to have moved.
+func TestDetectOrder_WorksWithoutUUIDs(t *testing.T) {
+	t.Parallel()
+
+	mk := func(uuid, tracker, desc string) common.FirewallRule {
+		return common.FirewallRule{
+			UUID: uuid, Tracker: tracker, Description: desc,
+			Type: common.RuleTypePass, Interfaces: []string{"wan"},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		old, newCfg  []common.FirewallRule
+		wantReorders int
+		wantPathPart string
+	}{
+		{
+			name:         "uuid-bearing rules (OPNsense MVC)",
+			old:          []common.FirewallRule{mk("u1", "", "a"), mk("u2", "", "b"), mk("u3", "", "c")},
+			newCfg:       []common.FirewallRule{mk("u3", "", "c"), mk("u1", "", "a"), mk("u2", "", "b")},
+			wantReorders: 3,
+			wantPathPart: "uuid=",
+		},
+		{
+			name:         "tracker-bearing rules (pfSense)",
+			old:          []common.FirewallRule{mk("", "t1", "a"), mk("", "t2", "b"), mk("", "t3", "c")},
+			newCfg:       []common.FirewallRule{mk("", "t3", "c"), mk("", "t1", "a"), mk("", "t2", "b")},
+			wantReorders: 3,
+			wantPathPart: "tracker=",
+		},
+		{
+			name:         "no identity: not reportable",
+			old:          []common.FirewallRule{mk("", "", "a"), mk("", "", "b")},
+			newCfg:       []common.FirewallRule{mk("", "", "b"), mk("", "", "a")},
+			wantReorders: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := NewEngine(
+				&common.CommonDevice{FirewallRules: tt.old},
+				&common.CommonDevice{FirewallRules: tt.newCfg},
+				Options{DetectOrder: true}, nil,
+			).Compare(context.Background())
+			require.NoError(t, err)
+
+			var reorders []Change
+			for _, c := range res.Changes {
+				if c.Type == ChangeReordered {
+					reorders = append(reorders, c)
+				}
+			}
+
+			assert.Len(t, reorders, tt.wantReorders)
+			if tt.wantPathPart != "" && len(reorders) > 0 {
+				assert.Contains(t, reorders[0].Path, tt.wantPathPart,
+					"the diff path must name the identity the rule was tracked by")
+			}
+		})
+	}
+}
+
+// TestCompareFirewallRules_DeletionDoesNotMisattributeEdit covers the case that
+// blind positional pairing got wrong.
+//
+// With `a, b, c(pass)` becoming `a, c(block)`, `a` anchors by content and both
+// `b` and `c` are left over. Pairing leftovers by position handed the surviving
+// `c` to `b`, reporting "b was modified into c" plus "c was removed" -- every
+// change surfaced, but attributed to the wrong rules. Similarity pairing picks
+// the real c-to-c pair, so the report reads "c was modified, b was removed".
+func TestCompareFirewallRules_DeletionDoesNotMisattributeEdit(t *testing.T) {
+	t.Parallel()
+
+	mk := func(desc string, typ common.FirewallRuleType) common.FirewallRule {
+		return common.FirewallRule{Type: typ, Description: desc, Interfaces: []string{"wan"}}
+	}
+
+	old := []common.FirewallRule{
+		mk("allow web", common.RuleTypePass),
+		mk("allow dns", common.RuleTypePass),
+		mk("allow ssh", common.RuleTypePass),
+	}
+	newCfg := []common.FirewallRule{
+		mk("allow web", common.RuleTypePass),
+		mk("allow ssh", common.RuleTypeBlock), // edited
+		// "allow dns" deleted
+	}
+
+	changes := NewAnalyzer().CompareFirewallRules(old, newCfg)
+	require.Len(t, changes, 2, "one edit and one deletion: %+v", changes)
+
+	byType := map[ChangeType]Change{}
+	for _, c := range changes {
+		byType[c.Type] = c
+	}
+
+	modified, ok := byType[ChangeModified]
+	require.True(t, ok, "the edit must be reported: %+v", changes)
+	assert.Contains(t, modified.Description, "allow ssh",
+		"the edit belongs to the rule that was actually edited")
+
+	removed, ok := byType[ChangeRemoved]
+	require.True(t, ok, "the deletion must be reported: %+v", changes)
+	assert.Contains(t, removed.Description, "allow dns",
+		"the deletion belongs to the rule that was actually deleted")
+}
+
+// TestRuleSimilarity_Ordering pins the relative weights: the operator's own
+// description outranks any single structural field, and an unrelated rule
+// scores below the floor for calling it an edit.
+func TestRuleSimilarity_Ordering(t *testing.T) {
+	t.Parallel()
+
+	base := common.FirewallRule{
+		Type: common.RuleTypePass, Description: "allow ssh", Interfaces: []string{"wan"},
+		Protocol:    "tcp",
+		Source:      common.RuleEndpoint{Address: "10.0.0.0/8"},
+		Destination: common.RuleEndpoint{Address: "192.168.1.1", Port: "22"},
+	}
+
+	sameNameEdited := base
+	sameNameEdited.Type = common.RuleTypeBlock
+
+	renamedButIdentical := base
+	renamedButIdentical.Description = "ssh (was: allow ssh)"
+
+	unrelated := common.FirewallRule{
+		Type: common.RuleTypeBlock, Description: "drop bogons", Interfaces: []string{"lan"},
+		Protocol:    "udp",
+		Source:      common.RuleEndpoint{Address: "any"},
+		Destination: common.RuleEndpoint{Address: "any", Port: "53"},
+	}
+
+	assert.GreaterOrEqual(t, ruleSimilarity(base, sameNameEdited), simMinScore,
+		"a rule keeping its description is the same rule edited")
+	assert.GreaterOrEqual(t, ruleSimilarity(base, renamedButIdentical), simMinScore,
+		"a renamed but otherwise identical rule is still the same rule")
+	assert.Less(t, ruleSimilarity(base, unrelated), simMinScore,
+		"a rule sharing nothing meaningful is not an edit of this one")
+}
+
+// TestCompareFirewallRules_SimilarityCapFallsBackToPosition exercises the bound
+// on the O(n*m) scoring. Above simMaxPairs leftovers the pairing degrades to
+// positional, which is what every input got before similarity existed, so the
+// changes must still all surface.
+func TestCompareFirewallRules_SimilarityCapFallsBackToPosition(t *testing.T) {
+	t.Parallel()
+
+	n := simMaxPairs + 10
+	old := make([]common.FirewallRule, n)
+	newCfg := make([]common.FirewallRule, n)
+	for i := range old {
+		old[i] = common.FirewallRule{
+			Type: common.RuleTypePass, Description: fmt.Sprintf("rule %d", i), Interfaces: []string{"wan"},
+		}
+		newCfg[i] = old[i]
+		newCfg[i].Type = common.RuleTypeBlock // every rule differs, so none anchor
+	}
+
+	changes := NewAnalyzer().CompareFirewallRules(old, newCfg)
+
+	assert.Len(t, changes, n, "every changed rule must still be reported past the cap")
+}

--- a/internal/diff/analyzer_firewall.go
+++ b/internal/diff/analyzer_firewall.go
@@ -83,42 +83,169 @@ func (a *Analyzer) CompareFirewallRules(old, newCfg []common.FirewallRule) []Cha
 		}
 	}
 
-	// Also compare by position for rules without UUIDs
-	changes = append(changes, a.compareRulesByPosition(old, newCfg)...)
+	// Rules without a UUID are compared separately; see compareRulesWithoutUUID.
+	changes = append(changes, a.compareRulesWithoutUUID(old, newCfg)...)
 
 	return changes
 }
 
-// compareRulesByPosition compares rules that don't have UUIDs by position.
-func (a *Analyzer) compareRulesByPosition(old, newCfg []common.FirewallRule) []Change {
+// Similarity weights for pairing leftover rules. A rule's description is the
+// operator's own name for it and survives most edits, so it counts for more
+// than any single match field; the interface list is the next strongest signal.
+const (
+	simWeightDescription = 4
+	simWeightInterfaces  = 2
+	simWeightField       = 1
+
+	// simMinScore is the floor for calling two rules the same rule edited:
+	// a matching description alone, or a matching interface list plus two
+	// other fields.
+	simMinScore = 4
+
+	// simMaxPairs bounds the similarity scoring; see itemPairer.maxPairs.
+	simMaxPairs = 512
+)
+
+// ruleSimilarity scores how likely a and b are the same rule after an edit.
+func ruleSimilarity(a, b common.FirewallRule) int {
+	score := 0
+
+	if a.Description != "" && a.Description == b.Description {
+		score += simWeightDescription
+	}
+
+	if slices.Equal(a.Interfaces, b.Interfaces) {
+		score += simWeightInterfaces
+	}
+
+	for _, same := range []bool{
+		a.Type == b.Type,
+		a.Protocol == b.Protocol,
+		a.Source.Address == b.Source.Address,
+		a.Destination.Address == b.Destination.Address,
+		a.Destination.Port == b.Destination.Port,
+	} {
+		if same {
+			score += simWeightField
+		}
+	}
+
+	return score
+}
+
+// compareRulesWithoutUUID compares the rules that carry no UUID.
+//
+// It previously compared only the rule COUNT, so any content change that left
+// the count intact was invisible: flipping a rule from pass to block, widening
+// a source to any, or disabling its logging all reported "no changes". That is
+// the common case rather than an edge case -- pfSense rules never carry a
+// <uuid>, and neither do older OPNsense ones.
+func (a *Analyzer) compareRulesWithoutUUID(old, newCfg []common.FirewallRule) []Change {
+	oldRules := rulesWithoutUUID(old)
+	newRules := rulesWithoutUUID(newCfg)
+
 	var changes []Change
 
-	// Filter to rules without UUIDs
-	var oldNoUUID, newNoUUID []common.FirewallRule
-	for _, r := range old {
-		if r.UUID == "" {
-			oldNoUUID = append(oldNoUUID, r)
-		}
+	pairer := itemPairer[common.FirewallRule]{
+		identity:   ruleIdentity,
+		equal:      rulesEqual,
+		similarity: ruleSimilarity,
+		minScore:   simMinScore,
+		maxPairs:   simMaxPairs,
 	}
-	for _, r := range newCfg {
-		if r.UUID == "" {
-			newNoUUID = append(newNoUUID, r)
+
+	res := pairer.pair(oldRules, newRules, func(oi, ni int) {
+		if rulesEqual(oldRules[oi], newRules[ni]) {
+			return
+		}
+
+		changes = append(changes, modifiedRuleChange(oldRules[oi], newRules[ni], ni))
+	})
+
+	for i, paired := range res.oldPaired {
+		if !paired {
+			changes = append(changes, removedRuleChange(oldRules[i], i))
 		}
 	}
 
-	// Simple length comparison for rules without UUIDs
-	if len(oldNoUUID) != len(newNoUUID) {
-		changes = append(changes, Change{
-			Type:        ChangeModified,
-			Section:     SectionFirewall,
-			Path:        "filter.rules",
-			Description: fmt.Sprintf("Rule count changed (without UUID): %d → %d", len(oldNoUUID), len(newNoUUID)),
-			OldValue:    fmt.Sprintf("%d rules", len(oldNoUUID)),
-			NewValue:    fmt.Sprintf("%d rules", len(newNoUUID)),
-		})
+	for i, paired := range res.newPaired {
+		if !paired {
+			changes = append(changes, addedRuleChange(newRules[i], i))
+		}
 	}
 
 	return changes
+}
+
+// rulesWithoutUUID returns the subset of rules carrying no UUID, preserving
+// config order.
+func rulesWithoutUUID(rules []common.FirewallRule) []common.FirewallRule {
+	var out []common.FirewallRule
+
+	for _, r := range rules {
+		if r.UUID == "" {
+			out = append(out, r)
+		}
+	}
+
+	return out
+}
+
+// rulePath renders the diff path for a rule without a UUID, falling back from
+// its tracker to its position.
+func rulePath(rule common.FirewallRule, index int) string {
+	if rule.Tracker != "" {
+		return fmt.Sprintf("filter.rule[tracker=%s]", rule.Tracker)
+	}
+
+	return fmt.Sprintf("filter.rule[%d]", index)
+}
+
+// modifiedRuleChange builds the Change for a rule whose content differs.
+func modifiedRuleChange(oldRule, newRule common.FirewallRule, index int) Change {
+	impact := ""
+	if isPermissiveRule(newRule) && !isPermissiveRule(oldRule) {
+		impact = "high"
+	}
+
+	return Change{
+		Type:           ChangeModified,
+		Section:        SectionFirewall,
+		Path:           rulePath(newRule, index),
+		Description:    "Modified rule: " + ruleDescription(newRule),
+		OldValue:       formatRule(oldRule),
+		NewValue:       formatRule(newRule),
+		SecurityImpact: impact,
+	}
+}
+
+// addedRuleChange builds the Change for a rule present only in the new config.
+func addedRuleChange(rule common.FirewallRule, index int) Change {
+	impact := ""
+	if isPermissiveRule(rule) {
+		impact = "high"
+	}
+
+	return Change{
+		Type:           ChangeAdded,
+		Section:        SectionFirewall,
+		Path:           rulePath(rule, index),
+		Description:    "Added rule: " + ruleDescription(rule),
+		NewValue:       formatRule(rule),
+		SecurityImpact: impact,
+	}
+}
+
+// removedRuleChange builds the Change for a rule present only in the old config.
+func removedRuleChange(rule common.FirewallRule, index int) Change {
+	return Change{
+		Type:           ChangeRemoved,
+		Section:        SectionFirewall,
+		Path:           rulePath(rule, index),
+		Description:    "Removed rule: " + ruleDescription(rule),
+		OldValue:       formatRule(rule),
+		SecurityImpact: "medium",
+	}
 }
 
 // ruleDescription returns the rule's description if set, or a synthesized
@@ -169,16 +296,77 @@ func formatEndpoint(ep common.RuleEndpoint) string {
 	return result
 }
 
-// rulesEqual reports whether two firewall rules are semantically equal by comparing
-// their type, description, protocol, disabled state, source, destination, and interfaces.
+// rulesEqual reports whether two firewall rules are semantically identical.
+//
+// Every field that changes what the rule matches, where it sits in pf
+// evaluation order, or whether it is recorded is compared. It previously
+// covered seven of the model's thirty-three, so a diff stayed silent when an
+// operator flipped a rule's direction, made it floating or quick, moved it to
+// another gateway, switched its state type, or turned its logging off -- the
+// last of which is how a rule change hides from the very logs an audit reads.
+//
+// UUID and Tracker are deliberately excluded: they identify the rule and are
+// what CompareFirewallRules pairs on, so comparing them here would report every
+// paired rule as modified.
+//
+// When a field is added to common.FirewallRule it belongs here.
+// TestRulesEqual_ComparesEveryFirewallRuleField fails until it is.
 func rulesEqual(a, b common.FirewallRule) bool {
+	return rulesMatchEqual(a, b) && rulesPrecedenceEqual(a, b) && rulesOptionsEqual(a, b)
+}
+
+// rulesMatchEqual compares the fields deciding which packets the rule matches.
+func rulesMatchEqual(a, b common.FirewallRule) bool {
 	return a.Type == b.Type &&
 		a.Description == b.Description &&
 		a.Protocol == b.Protocol &&
 		a.Disabled == b.Disabled &&
 		a.Source == b.Source &&
 		a.Destination == b.Destination &&
-		slices.Equal(a.Interfaces, b.Interfaces)
+		slices.Equal(a.Interfaces, b.Interfaces) &&
+		a.IPProtocol == b.IPProtocol &&
+		a.ICMPType == b.ICMPType &&
+		a.ICMP6Type == b.ICMP6Type &&
+		a.TCPFlags1 == b.TCPFlags1 &&
+		a.TCPFlags2 == b.TCPFlags2 &&
+		a.TCPFlagsAny == b.TCPFlagsAny
+}
+
+// rulesPrecedenceEqual compares the fields deciding where the rule sits in pf
+// evaluation order and where matched traffic is sent.
+func rulesPrecedenceEqual(a, b common.FirewallRule) bool {
+	return a.Direction == b.Direction &&
+		a.Floating == b.Floating &&
+		a.Quick == b.Quick &&
+		a.Target == b.Target &&
+		objectRefsEqual(a.TargetRef, b.TargetRef) &&
+		a.Gateway == b.Gateway &&
+		a.AssociatedRuleID == b.AssociatedRuleID
+}
+
+// rulesOptionsEqual compares logging, state handling and connection limits.
+func rulesOptionsEqual(a, b common.FirewallRule) bool {
+	return a.Log == b.Log &&
+		a.StateType == b.StateType &&
+		a.StateTimeout == b.StateTimeout &&
+		a.MaxSrcNodes == b.MaxSrcNodes &&
+		a.MaxSrcConn == b.MaxSrcConn &&
+		a.MaxSrcConnRate == b.MaxSrcConnRate &&
+		a.MaxSrcConnRates == b.MaxSrcConnRates &&
+		a.AllowOpts == b.AllowOpts &&
+		a.DisableReplyTo == b.DisableReplyTo &&
+		a.NoPfSync == b.NoPfSync &&
+		a.NoSync == b.NoSync
+}
+
+// objectRefsEqual compares two optional named-object references by value, so a
+// rule that switches from one alias to another is reported as modified.
+func objectRefsEqual(a, b *common.ObjectRef) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return *a == *b
 }
 
 // isPermissiveRule reports whether a firewall rule is an unrestricted pass rule

--- a/internal/diff/analyzer_nat.go
+++ b/internal/diff/analyzer_nat.go
@@ -1,8 +1,11 @@
 package diff
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 
 	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
 )
@@ -47,30 +50,9 @@ func (a *Analyzer) CompareNAT(old, newCfg common.NATConfig) []Change {
 		})
 	}
 
-	// Compare outbound rule counts
-	if len(old.OutboundRules) != len(newCfg.OutboundRules) {
-		changes = append(changes, Change{
-			Type:        ChangeModified,
-			Section:     SectionNAT,
-			Path:        "nat.outbound.rules",
-			Description: "Outbound NAT rule count changed",
-			OldValue:    fmt.Sprintf("%d rules", len(old.OutboundRules)),
-			NewValue:    fmt.Sprintf("%d rules", len(newCfg.OutboundRules)),
-		})
-	}
-
-	// Compare inbound (port forward) rule counts
-	if len(old.InboundRules) != len(newCfg.InboundRules) {
-		changes = append(changes, Change{
-			Type:           ChangeModified,
-			Section:        SectionNAT,
-			Path:           "nat.inbound.rules",
-			Description:    "Port forward rule count changed",
-			OldValue:       fmt.Sprintf("%d rules", len(old.InboundRules)),
-			NewValue:       fmt.Sprintf("%d rules", len(newCfg.InboundRules)),
-			SecurityImpact: "medium",
-		})
-	}
+	// Compare outbound and inbound rules per rule, not by list length.
+	changes = append(changes, compareOutboundNATRules(old.OutboundRules, newCfg.OutboundRules)...)
+	changes = append(changes, compareInboundNATRules(old.InboundRules, newCfg.InboundRules)...)
 
 	// Compare NAT boolean settings
 	if old.ReflectionDisabled != newCfg.ReflectionDisabled {
@@ -102,6 +84,357 @@ func (a *Analyzer) CompareNAT(old, newCfg common.NATConfig) []Change {
 			OldValue:    strconv.FormatBool(old.BiNATEnabled),
 			NewValue:    strconv.FormatBool(newCfg.BiNATEnabled),
 		})
+	}
+
+	return changes
+}
+
+// NAT rule similarity weights, mirroring the firewall ones: the operator's own
+// description outranks any single field, and the interface list is the next
+// strongest signal.
+const (
+	natSimWeightDescription = 4
+	natSimWeightInterfaces  = 2
+	natSimWeightField       = 1
+
+	// natSimMinScore is the floor for calling two NAT rules the same rule
+	// edited: a matching description alone, or a matching interface list plus
+	// two other fields.
+	natSimMinScore = 4
+
+	// natSimMaxPairs bounds the similarity scoring; see itemPairer.maxPairs.
+	natSimMaxPairs = 512
+)
+
+// natRuleIdentity returns an outbound NAT rule's stable id. No vendor observed
+// so far populates it -- neither pfSense nor the OPNsense MVC configs carry a
+// UUID on NAT rules -- so pairing normally falls through to content and
+// similarity. It is honoured when present rather than assumed absent.
+func natRuleIdentity(rule common.NATRule) (string, bool) {
+	if rule.UUID == "" {
+		return "", false
+	}
+
+	return "uuid=" + rule.UUID, true
+}
+
+// inboundNATRuleIdentity is natRuleIdentity for port forwards.
+func inboundNATRuleIdentity(rule common.InboundNATRule) (string, bool) {
+	if rule.UUID == "" {
+		return "", false
+	}
+
+	return "uuid=" + rule.UUID, true
+}
+
+// natRulesEqual reports whether two outbound NAT rules are semantically
+// identical. Every field that changes what the rule matches or how it
+// translates is compared; a field omitted here produces no diff entry at all.
+//
+// UUID is excluded because it is the identity the pairing keys on.
+//
+// When a field is added to common.NATRule it belongs here.
+// TestNATRulesEqual_ComparesEveryField fails until it is.
+func natRulesEqual(a, b common.NATRule) bool {
+	return slices.Equal(a.Interfaces, b.Interfaces) &&
+		a.IPProtocol == b.IPProtocol &&
+		a.Protocol == b.Protocol &&
+		a.Source == b.Source &&
+		a.Destination == b.Destination &&
+		a.Target == b.Target &&
+		objectRefsEqual(a.TargetRef, b.TargetRef) &&
+		a.SourcePort == b.SourcePort &&
+		objectRefsEqual(a.SourcePortRef, b.SourcePortRef) &&
+		a.NatPort == b.NatPort &&
+		objectRefsEqual(a.NatPortRef, b.NatPortRef) &&
+		a.PoolOpts == b.PoolOpts &&
+		a.StaticNatPort == b.StaticNatPort &&
+		a.NoNat == b.NoNat &&
+		a.Disabled == b.Disabled &&
+		a.Log == b.Log &&
+		a.Description == b.Description &&
+		a.Category == b.Category &&
+		a.Tag == b.Tag &&
+		a.Tagged == b.Tagged
+}
+
+// inboundNATRulesEqual is natRulesEqual for port forwards. InternalIP and
+// InternalPort are the translation target: a change there redirects inbound
+// traffic to a different host, which is the change this comparison exists to
+// surface.
+//
+// When a field is added to common.InboundNATRule it belongs here.
+// TestInboundNATRulesEqual_ComparesEveryField fails until it is.
+func inboundNATRulesEqual(a, b common.InboundNATRule) bool {
+	return slices.Equal(a.Interfaces, b.Interfaces) &&
+		a.IPProtocol == b.IPProtocol &&
+		a.Protocol == b.Protocol &&
+		a.Source == b.Source &&
+		a.Destination == b.Destination &&
+		a.ExternalPort == b.ExternalPort &&
+		objectRefsEqual(a.ExternalPortRef, b.ExternalPortRef) &&
+		a.InternalIP == b.InternalIP &&
+		objectRefsEqual(a.InternalIPRef, b.InternalIPRef) &&
+		a.InternalPort == b.InternalPort &&
+		objectRefsEqual(a.InternalPortRef, b.InternalPortRef) &&
+		a.LocalPort == b.LocalPort &&
+		objectRefsEqual(a.LocalPortRef, b.LocalPortRef) &&
+		a.Reflection == b.Reflection &&
+		a.NATReflection == b.NATReflection &&
+		a.AssociatedRuleID == b.AssociatedRuleID &&
+		a.Priority == b.Priority &&
+		a.NoRDR == b.NoRDR &&
+		a.NoSync == b.NoSync &&
+		a.Disabled == b.Disabled &&
+		a.Log == b.Log &&
+		a.Description == b.Description
+}
+
+// natRuleSimilarity scores how likely two outbound NAT rules are the same rule
+// after an edit.
+func natRuleSimilarity(a, b common.NATRule) int {
+	score := 0
+
+	if a.Description != "" && a.Description == b.Description {
+		score += natSimWeightDescription
+	}
+
+	if slices.Equal(a.Interfaces, b.Interfaces) {
+		score += natSimWeightInterfaces
+	}
+
+	for _, same := range []bool{
+		a.Protocol == b.Protocol,
+		a.Source.Address == b.Source.Address,
+		a.Destination.Address == b.Destination.Address,
+		a.Target == b.Target,
+	} {
+		if same {
+			score += natSimWeightField
+		}
+	}
+
+	return score
+}
+
+// inboundNATRuleSimilarity is natRuleSimilarity for port forwards.
+func inboundNATRuleSimilarity(a, b common.InboundNATRule) int {
+	score := 0
+
+	if a.Description != "" && a.Description == b.Description {
+		score += natSimWeightDescription
+	}
+
+	if slices.Equal(a.Interfaces, b.Interfaces) {
+		score += natSimWeightInterfaces
+	}
+
+	for _, same := range []bool{
+		a.Protocol == b.Protocol,
+		a.ExternalPort == b.ExternalPort,
+		a.InternalIP == b.InternalIP,
+		a.InternalPort == b.InternalPort,
+	} {
+		if same {
+			score += natSimWeightField
+		}
+	}
+
+	return score
+}
+
+// natRuleDescription names a NAT rule for diff output, falling back to a
+// synthesized summary when the operator left the description blank.
+func natRuleDescription(rule common.NATRule) string {
+	if rule.Description != "" {
+		return rule.Description
+	}
+
+	return cmp.Or(rule.Source.Address, addressUnknown) + " -> " + cmp.Or(rule.Target, addressUnknown)
+}
+
+// inboundNATRuleDescription is natRuleDescription for port forwards.
+func inboundNATRuleDescription(rule common.InboundNATRule) string {
+	if rule.Description != "" {
+		return rule.Description
+	}
+
+	return joinHostPort(formatEndpoint(rule.Destination), rule.ExternalPort) +
+		" -> " + joinHostPort(cmp.Or(rule.InternalIP, addressUnknown), rule.InternalPort)
+}
+
+// formatNATRule renders an outbound NAT rule compactly for diff output.
+func formatNATRule(rule common.NATRule) string {
+	var parts []string
+	if len(rule.Interfaces) > 0 {
+		parts = append(parts, "if="+strings.Join(rule.Interfaces, ","))
+	}
+
+	if rule.Protocol != "" {
+		parts = append(parts, "proto="+rule.Protocol)
+	}
+
+	parts = append(parts,
+		"src="+formatEndpoint(rule.Source),
+		"dst="+formatEndpoint(rule.Destination),
+		"target="+cmp.Or(rule.Target, addressUnknown))
+
+	if rule.Disabled {
+		parts = append(parts, "disabled")
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// formatInboundNATRule renders a port forward compactly for diff output.
+//
+// Each component is omitted when empty rather than printed as "unknown": a port
+// forward's external port lives in Destination.Port on some vendors and in
+// ExternalPort on others, so blindly printing both yields "wanip:80:unknown".
+func formatInboundNATRule(rule common.InboundNATRule) string {
+	var parts []string
+	if len(rule.Interfaces) > 0 {
+		parts = append(parts, "if="+strings.Join(rule.Interfaces, ","))
+	}
+
+	if rule.Protocol != "" {
+		parts = append(parts, "proto="+rule.Protocol)
+	}
+
+	parts = append(parts,
+		"ext="+joinHostPort(formatEndpoint(rule.Destination), rule.ExternalPort),
+		"int="+joinHostPort(cmp.Or(rule.InternalIP, addressUnknown), rule.InternalPort))
+
+	if rule.Disabled {
+		parts = append(parts, "disabled")
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// joinHostPort appends ":port" to host only when port is set and host does not
+// already carry one (formatEndpoint adds the endpoint's own port).
+func joinHostPort(host, port string) string {
+	if port == "" || strings.Contains(host, ":") {
+		return host
+	}
+
+	return host + ":" + port
+}
+
+// compareOutboundNATRules reports per-rule outbound NAT changes.
+//
+// This previously compared only len(old) != len(new), so every content change
+// that left the count intact was invisible: retargeting a rule, moving it to
+// another interface, or disabling it all reported nothing.
+func compareOutboundNATRules(old, newCfg []common.NATRule) []Change {
+	var changes []Change
+
+	pairer := itemPairer[common.NATRule]{
+		identity:   natRuleIdentity,
+		equal:      natRulesEqual,
+		similarity: natRuleSimilarity,
+		minScore:   natSimMinScore,
+		maxPairs:   natSimMaxPairs,
+	}
+
+	res := pairer.pair(old, newCfg, func(oi, ni int) {
+		if natRulesEqual(old[oi], newCfg[ni]) {
+			return
+		}
+
+		changes = append(changes, Change{
+			Type:        ChangeModified,
+			Section:     SectionNAT,
+			Path:        fmt.Sprintf("nat.outbound.rules[%d]", ni),
+			Description: "Modified outbound NAT rule: " + natRuleDescription(newCfg[ni]),
+			OldValue:    formatNATRule(old[oi]),
+			NewValue:    formatNATRule(newCfg[ni]),
+		})
+	})
+
+	for i, paired := range res.oldPaired {
+		if !paired {
+			changes = append(changes, Change{
+				Type:        ChangeRemoved,
+				Section:     SectionNAT,
+				Path:        fmt.Sprintf("nat.outbound.rules[%d]", i),
+				Description: "Removed outbound NAT rule: " + natRuleDescription(old[i]),
+				OldValue:    formatNATRule(old[i]),
+			})
+		}
+	}
+
+	for i, paired := range res.newPaired {
+		if !paired {
+			changes = append(changes, Change{
+				Type:        ChangeAdded,
+				Section:     SectionNAT,
+				Path:        fmt.Sprintf("nat.outbound.rules[%d]", i),
+				Description: "Added outbound NAT rule: " + natRuleDescription(newCfg[i]),
+				NewValue:    formatNATRule(newCfg[i]),
+			})
+		}
+	}
+
+	return changes
+}
+
+// compareInboundNATRules reports per-rule port-forward changes.
+//
+// Like the outbound rules this compared only the count, so a port forward
+// retargeted to a different internal host -- the most consequential NAT change
+// there is -- produced no diff entry. The nat.inbound path makes the security
+// scorer's port-forward-change pattern apply to every entry.
+func compareInboundNATRules(old, newCfg []common.InboundNATRule) []Change {
+	var changes []Change
+
+	pairer := itemPairer[common.InboundNATRule]{
+		identity:   inboundNATRuleIdentity,
+		equal:      inboundNATRulesEqual,
+		similarity: inboundNATRuleSimilarity,
+		minScore:   natSimMinScore,
+		maxPairs:   natSimMaxPairs,
+	}
+
+	res := pairer.pair(old, newCfg, func(oi, ni int) {
+		if inboundNATRulesEqual(old[oi], newCfg[ni]) {
+			return
+		}
+
+		changes = append(changes, Change{
+			Type:        ChangeModified,
+			Section:     SectionNAT,
+			Path:        fmt.Sprintf("nat.inbound.rules[%d]", ni),
+			Description: "Modified port forward: " + inboundNATRuleDescription(newCfg[ni]),
+			OldValue:    formatInboundNATRule(old[oi]),
+			NewValue:    formatInboundNATRule(newCfg[ni]),
+		})
+	})
+
+	for i, paired := range res.oldPaired {
+		if !paired {
+			changes = append(changes, Change{
+				Type:        ChangeRemoved,
+				Section:     SectionNAT,
+				Path:        fmt.Sprintf("nat.inbound.rules[%d]", i),
+				Description: "Removed port forward: " + inboundNATRuleDescription(old[i]),
+				OldValue:    formatInboundNATRule(old[i]),
+			})
+		}
+	}
+
+	for i, paired := range res.newPaired {
+		if !paired {
+			changes = append(changes, Change{
+				Type:           ChangeAdded,
+				Section:        SectionNAT,
+				Path:           fmt.Sprintf("nat.inbound.rules[%d]", i),
+				Description:    "Added port forward: " + inboundNATRuleDescription(newCfg[i]),
+				NewValue:       formatInboundNATRule(newCfg[i]),
+				SecurityImpact: "high",
+			})
+		}
 	}
 
 	return changes

--- a/internal/diff/analyzer_nat_rules_test.go
+++ b/internal/diff/analyzer_nat_rules_test.go
@@ -1,0 +1,116 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	common "github.com/EvilBit-Labs/opnDossier/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNATRulesEqual_ComparesEveryField guards the under-reporting that
+// motivated per-rule NAT comparison. A field missing from the equality helper
+// does not weaken a diff entry, it removes the entry.
+func TestNATRulesEqual_ComparesEveryField(t *testing.T) {
+	t.Parallel()
+
+	assertEqualityCoversEveryField(t, natRulesEqual, map[string]string{
+		"UUID": "identity; the pairing keys on it",
+	})
+}
+
+// TestInboundNATRulesEqual_ComparesEveryField is the same guard for port
+// forwards, where InternalIP is the translation target.
+func TestInboundNATRulesEqual_ComparesEveryField(t *testing.T) {
+	t.Parallel()
+
+	assertEqualityCoversEveryField(t, inboundNATRulesEqual, map[string]string{
+		"UUID": "identity; the pairing keys on it",
+	})
+}
+
+// TestCompareNAT_DetectsContentChanges is the end-to-end half: CompareNAT
+// compared only len(OutboundRules) and len(InboundRules), so any edit that left
+// the counts intact reported nothing at all. No NAT rule in any shipped fixture
+// carries a UUID, so this is the path every real config takes.
+func TestCompareNAT_DetectsContentChanges(t *testing.T) {
+	t.Parallel()
+
+	base := common.NATConfig{
+		OutboundMode: common.OutboundAdvanced,
+		OutboundRules: []common.NATRule{{
+			Interfaces: []string{"wan"}, Protocol: "tcp", Description: "lan egress",
+			Source: common.RuleEndpoint{Address: "192.168.1.0/24"},
+			Target: "203.0.113.1",
+		}},
+		InboundRules: []common.InboundNATRule{{
+			Interfaces: []string{"wan"}, Protocol: "tcp", Description: "web",
+			ExternalPort: "443", InternalIP: "192.168.1.10", InternalPort: "443",
+		}},
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*common.NATConfig)
+		wantHit string
+	}{
+		{"outbound target retargeted", func(c *common.NATConfig) {
+			c.OutboundRules[0].Target = "203.0.113.99"
+		}, "outbound NAT rule"},
+		{"outbound moved to another interface", func(c *common.NATConfig) {
+			c.OutboundRules[0].Interfaces = []string{"opt1"}
+		}, "outbound NAT rule"},
+		{"outbound disabled", func(c *common.NATConfig) {
+			c.OutboundRules[0].Disabled = true
+		}, "outbound NAT rule"},
+		{"port forward retargeted to another host", func(c *common.NATConfig) {
+			c.InboundRules[0].InternalIP = "192.168.1.66"
+		}, "port forward"},
+		{"port forward internal port changed", func(c *common.NATConfig) {
+			c.InboundRules[0].InternalPort = "8443"
+		}, "port forward"},
+		{"port forward logging turned off", func(c *common.NATConfig) {
+			c.InboundRules[0].Log = false
+			c.InboundRules[0].NoRDR = true
+		}, "port forward"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			oldCfg := deepCopyNAT(base)
+			newCfg := deepCopyNAT(base)
+			tt.mutate(&newCfg)
+
+			changes := NewAnalyzer().CompareNAT(oldCfg, newCfg)
+
+			require.NotEmpty(t, changes, "a NAT content change must produce a diff entry")
+
+			var found bool
+			for _, c := range changes {
+				if c.Type == ChangeModified && strings.Contains(c.Description, tt.wantHit) {
+					found = true
+				}
+			}
+			assert.True(t, found, "expected a modified %s entry, got %+v", tt.wantHit, changes)
+		})
+	}
+}
+
+// deepCopyNAT clones the slices so table cases cannot mutate each other.
+func deepCopyNAT(c common.NATConfig) common.NATConfig {
+	out := c
+	out.OutboundRules = make([]common.NATRule, len(c.OutboundRules))
+	copy(out.OutboundRules, c.OutboundRules)
+	for i := range out.OutboundRules {
+		out.OutboundRules[i].Interfaces = append([]string(nil), c.OutboundRules[i].Interfaces...)
+	}
+	out.InboundRules = make([]common.InboundNATRule, len(c.InboundRules))
+	copy(out.InboundRules, c.InboundRules)
+	for i := range out.InboundRules {
+		out.InboundRules[i].Interfaces = append([]string(nil), c.InboundRules[i].Interfaces...)
+	}
+	return out
+}

--- a/internal/diff/analyzer_users.go
+++ b/internal/diff/analyzer_users.go
@@ -78,12 +78,21 @@ func (a *Analyzer) CompareUsers(old, newCfg []common.User) []Change {
 	return changes
 }
 
-// usersEqual reports whether two users are semantically equal by comparing
-// their name, description, scope, group, and disabled state.
+// usersEqual reports whether two users are semantically equal.
+//
+// It previously compared five of the model's seven fields, omitting UID and
+// APIKeys. A user gaining, losing or rotating an API credential therefore
+// produced no diff entry at all, which is the change an operator reviewing a
+// config most needs to see.
+//
+// When a field is added to common.User it belongs here.
+// TestUsersEqual_ComparesEveryUserField fails until it is.
 func usersEqual(a, b common.User) bool {
 	return a.Name == b.Name &&
 		a.Description == b.Description &&
 		a.Scope == b.Scope &&
 		a.GroupName == b.GroupName &&
-		a.Disabled == b.Disabled
+		a.Disabled == b.Disabled &&
+		a.UID == b.UID &&
+		slices.Equal(a.APIKeys, b.APIKeys)
 }

--- a/internal/diff/engine.go
+++ b/internal/diff/engine.go
@@ -209,29 +209,55 @@ func (e *Engine) addReorderChanges(result *Result) {
 
 // detectFirewallReorders uses the order detector to find reordered firewall rules.
 func (e *Engine) detectFirewallReorders() []Change {
-	oldUUIDs := extractRuleUUIDs(e.oldConfig.FirewallRules)
-	newUUIDs := extractRuleUUIDs(e.newConfig.FirewallRules)
+	oldIDs := extractRuleIdentities(e.oldConfig.FirewallRules)
+	newIDs := extractRuleIdentities(e.newConfig.FirewallRules)
 
-	reorders := e.orderDetector.DetectReorders(oldUUIDs, newUUIDs)
+	reorders := e.orderDetector.DetectReorders(oldIDs, newIDs)
 	changes := make([]Change, 0, len(reorders))
 	for _, r := range reorders {
 		changes = append(changes, Change{
 			Type:        ChangeReordered,
 			Section:     SectionFirewall,
-			Path:        fmt.Sprintf("filter.rule[uuid=%s]", r.ID),
+			Path:        "filter.rule[" + r.ID + "]",
 			Description: fmt.Sprintf("Rule moved from position %d to %d", r.OldPosition, r.NewPosition),
 		})
 	}
 	return changes
 }
 
-// extractRuleUUIDs returns the ordered list of UUIDs from firewall rules.
-func extractRuleUUIDs(rules []common.FirewallRule) []string {
-	uuids := make([]string, 0, len(rules))
+// ruleIdentity returns the stable identifier a rule can be tracked by across
+// two configs: its UUID when it has one, otherwise its pfSense <tracker>. The
+// second return is false when the rule carries neither, in which case it cannot
+// participate in order detection -- a rule with no identity is
+// indistinguishable from its peers, so "it moved" is not a claim that can be
+// made about it.
+func ruleIdentity(rule common.FirewallRule) (string, bool) {
+	if rule.UUID != "" {
+		return "uuid=" + rule.UUID, true
+	}
+
+	if rule.Tracker != "" {
+		return "tracker=" + rule.Tracker, true
+	}
+
+	return "", false
+}
+
+// extractRuleIdentities returns the ordered identifiers of the rules that have
+// one.
+//
+// This previously read UUIDs only, so it returned an empty list for any config
+// whose rules carry no <uuid> -- which is every pfSense config and every older
+// OPNsense one. DetectReorders then had nothing to compare and --detect-order
+// was a documented flag that silently did nothing for most real inputs.
+func extractRuleIdentities(rules []common.FirewallRule) []string {
+	ids := make([]string, 0, len(rules))
+
 	for _, r := range rules {
-		if r.UUID != "" {
-			uuids = append(uuids, r.UUID)
+		if id, ok := ruleIdentity(r); ok {
+			ids = append(ids, id)
 		}
 	}
-	return uuids
+
+	return ids
 }

--- a/internal/diff/pairing.go
+++ b/internal/diff/pairing.go
@@ -1,0 +1,203 @@
+package diff
+
+import "slices"
+
+// itemPairer matches the items of two config lists across a diff, so a change
+// to one item is reported against that item rather than inferred from the list
+// length.
+//
+// The passes run in order and each only considers what the previous ones left
+// alone:
+//
+//  1. identity -- a stable per-item id (a UUID, a pfSense <tracker>) when the
+//     vendor supplies one. Survives both reordering and edits.
+//  2. content -- byte-identical items anchor in place, so only genuine edits
+//     and additions are left for the final pass to consider.
+//  3. similarity -- the leftovers are scored against each other and matched
+//     best-first, so a deletion cannot shift an edit onto its neighbour.
+//
+// Whatever is unpaired at the end is a real addition or removal.
+type itemPairer[T any] struct {
+	// identity returns a stable id for an item, and false when it has none.
+	identity func(T) (string, bool)
+	// equal reports whether two items are semantically identical. It must
+	// compare every meaningful field: a field it ignores produces no diff
+	// entry at all, rather than a less detailed one.
+	equal func(a, b T) bool
+	// similarity scores how likely two items are the same item after an edit.
+	similarity func(a, b T) int
+	// minScore is the floor for calling a scored pair an edit rather than a
+	// coincidence.
+	minScore int
+	// maxPairs bounds the O(n*m) similarity scoring. Above this many leftovers
+	// on either side, pairing degrades to positional.
+	maxPairs int
+}
+
+// pairResult records which positions found a partner.
+type pairResult struct {
+	oldPaired, newPaired []bool
+}
+
+// pair matches old against newItems, calling onPair for every matched
+// position. Callers decide from onPair whether a pair is an edit, and read the
+// result to find the additions and removals.
+func (p itemPairer[T]) pair(old, newItems []T, onPair func(oi, ni int)) pairResult {
+	res := pairResult{
+		oldPaired: make([]bool, len(old)),
+		newPaired: make([]bool, len(newItems)),
+	}
+
+	bind := func(oi, ni int) {
+		res.oldPaired[oi] = true
+		res.newPaired[ni] = true
+		onPair(oi, ni)
+	}
+
+	p.pairByIdentity(old, newItems, &res, bind)
+	p.pairByContent(old, newItems, &res, bind)
+	p.pairBySimilarity(old, newItems, &res, bind)
+
+	return res
+}
+
+// pairByIdentity matches items sharing a non-empty id. A duplicated id is not a
+// usable identity and is skipped.
+func (p itemPairer[T]) pairByIdentity(old, newItems []T, res *pairResult, bind func(oi, ni int)) {
+	if p.identity == nil {
+		return
+	}
+
+	byID := make(map[string]int, len(newItems))
+
+	for i, item := range newItems {
+		id, ok := p.identity(item)
+		if !ok {
+			continue
+		}
+
+		if _, seen := byID[id]; seen {
+			byID[id] = -1
+
+			continue
+		}
+
+		byID[id] = i
+	}
+
+	for oi, item := range old {
+		id, ok := p.identity(item)
+		if !ok {
+			continue
+		}
+
+		ni, found := byID[id]
+		if !found || ni < 0 || res.newPaired[ni] {
+			continue
+		}
+
+		bind(oi, ni)
+	}
+}
+
+// pairByContent anchors the items that did not change, so the similarity pass
+// only has to reason about genuine edits.
+func (p itemPairer[T]) pairByContent(old, newItems []T, res *pairResult, bind func(oi, ni int)) {
+	for oi := range old {
+		if res.oldPaired[oi] {
+			continue
+		}
+
+		for ni := range newItems {
+			if res.newPaired[ni] || !p.equal(old[oi], newItems[ni]) {
+				continue
+			}
+
+			bind(oi, ni)
+
+			break
+		}
+	}
+}
+
+// scoredPair is one candidate (old, new) combination and its similarity.
+type scoredPair struct {
+	oldIdx, newIdx, score int
+}
+
+// pairBySimilarity matches the remaining items best-first. Ties break on the
+// earliest old item, then the earliest new item, so output is deterministic
+// (GOTCHAS 3.1).
+func (p itemPairer[T]) pairBySimilarity(old, newItems []T, res *pairResult, bind func(oi, ni int)) {
+	oldLeft := unpairedIndexes(res.oldPaired)
+	newLeft := unpairedIndexes(res.newPaired)
+
+	if len(oldLeft) == 0 || len(newLeft) == 0 {
+		return
+	}
+
+	if p.similarity == nil || len(oldLeft) > p.maxPairs || len(newLeft) > p.maxPairs {
+		p.pairByPosition(oldLeft, newLeft, res, bind)
+
+		return
+	}
+
+	candidates := make([]scoredPair, 0, len(oldLeft)*len(newLeft))
+
+	for _, oi := range oldLeft {
+		for _, ni := range newLeft {
+			if score := p.similarity(old[oi], newItems[ni]); score >= p.minScore {
+				candidates = append(candidates, scoredPair{oldIdx: oi, newIdx: ni, score: score})
+			}
+		}
+	}
+
+	slices.SortFunc(candidates, func(a, b scoredPair) int {
+		if a.score != b.score {
+			return b.score - a.score
+		}
+
+		if a.oldIdx != b.oldIdx {
+			return a.oldIdx - b.oldIdx
+		}
+
+		return a.newIdx - b.newIdx
+	})
+
+	for _, c := range candidates {
+		if res.oldPaired[c.oldIdx] || res.newPaired[c.newIdx] {
+			continue
+		}
+
+		bind(c.oldIdx, c.newIdx)
+	}
+}
+
+// pairByPosition is the fallback when similarity scoring is unavailable or the
+// leftover sets are too large to score.
+func (p itemPairer[T]) pairByPosition(oldLeft, newLeft []int, res *pairResult, bind func(oi, ni int)) {
+	for i, oi := range oldLeft {
+		if i >= len(newLeft) {
+			return
+		}
+
+		if res.oldPaired[oi] || res.newPaired[newLeft[i]] {
+			continue
+		}
+
+		bind(oi, newLeft[i])
+	}
+}
+
+// unpairedIndexes returns the positions still awaiting a partner.
+func unpairedIndexes(paired []bool) []int {
+	var out []int
+
+	for i, p := range paired {
+		if !p {
+			out = append(out, i)
+		}
+	}
+
+	return out
+}


### PR DESCRIPTION
## Summary

`opndossier diff` answered "No changes detected" for several of the changes an operator most needs to see. On the shipped `testdata/pfsense/config-pfSense.xml`, flipping a firewall rule from pass to block reported nothing, and so did redirecting a port forward to a different internal host.

Four independent gaps, all reachable on ordinary configs.

## What was wrong

**Firewall rules were paired by UUID, which pfSense never writes.** Ten of the thirteen fixtures in `testdata/` have none, and older OPNsense configs do not either. The fallback compared only the rule COUNT, so any content change that left the count intact was invisible.

**`--detect-order` had the same dependency.** `extractRuleUUIDs` dropped every rule without one, so a documented, accepted flag silently found nothing on pfSense. It now keys on UUID, else the pfSense tracker; rules carrying neither stay out, because a rule indistinguishable from its peers cannot be said to have moved.

**NAT rules were compared by count alone in both directions.** No NAT rule in any fixture carries a `uuid`, so this was the path every real config took, and it hid port forwards being retargeted.

**The equality helpers had drifted from the models.** `rulesEqual` compared 7 of `common.FirewallRule`'s 33 fields and `usersEqual` 5 of `common.User`'s 7. A field missing from either does not weaken the diff entry, it removes the entry, so the diff stayed silent on a rule's direction being reversed, on it becoming floating or quick, on its gateway being redirected, its state type weakened or its logging turned off, and on a user's UID changing or an API credential being added, rotated or removed.

## What changed

Matching now goes through one `itemPairer` in `internal/diff/pairing.go`, used by firewall rules and both NAT rule kinds: by identity where a vendor supplies one, then by exact content so unchanged rules anchor in place, then by similarity so a deletion cannot shift an edit onto its neighbour.

Pairing leftovers positionally misattributed edits. With `a, b, c(pass)` becoming `a, c(block)`, the surviving `c` was handed to `b`, reporting "b modified into c" plus "c removed" when the truth is "c modified" and "b removed". Similarity weights the description 4, the interface list 2, and one each for the match fields.

## Acceptance criteria

- [x] A pass-to-block flip on the shipped pfSense fixture is reported.
- [x] A retargeted port forward is reported.
- [x] `--detect-order` works on configs with no rule UUIDs.
- [x] The equality helpers cover every field on the models they compare.
- [x] A deletion adjacent to an edit does not misattribute either.
- [x] `GOTCHAS.md` records all three patterns.

## Test plan

- `internal/diff/analyzer_completeness_test.go` asserts the equality helpers cover every field on `common.FirewallRule` and `common.User` by reflection, so a field added later fails the test rather than silently going uncompared.
- `internal/diff/analyzer_nat_rules_test.go` covers NAT pairing without UUIDs, including the retarget case.
- Full suite green, `golangci-lint` clean on a cold cache.
