### PR TITLE
ci: align the golangci-lint pin with mise.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,13 @@ jobs:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9 # The version should be handled by mise, but we specify it here to ensure consistency
+      # Keep `version` in lockstep with the golangci-lint pin in mise.toml.
+      # These are two independent pins: mise drives `just lint` locally, this
+      # one drives CI. When they drift, CI and developers run different
+      # linters against the same tree and CI silently becomes the weaker gate.
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: v2.12.2
+          version: v2.13.2
 
   # ─────────────────────────────────────────────────────────────────────────
   # Test - Run tests across platforms and Go versions


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` pinned golangci-lint to `v2.12.2` while `mise.toml` pins `2.13.2`. Two independent pins for the same tool, so a routine mise bump left CI running an older linter than every developer.

Bumps CI to `v2.13.2` so the two agree.

## Why it matters

`just lint` resolves golangci-lint through mise; CI resolves it through the action's own `version` input. Once they diverge, CI and developers lint the same tree with different tools — and CI was the weaker of the two:

```text
golangci-lint 2.13.2 run ./...   ->  13 issues   exit 1     # just lint / just ci-check
golangci-lint 2.12.2 run ./...   ->   0 issues   exit 0     # CI, same tree, same config
```

Those 13 were real `staticcheck` SA1019 findings, resolved separately in #813. CI never reported them.

The old inline comment said the version "should be handled by mise, but we specify it here to ensure consistency." Hardcoding it is what *broke* consistency: two files now had to be updated in lockstep, and only one of them is what developers actually run. The replacement comment says plainly that the two pins must move together.

A single source of truth would be better still — letting the action inherit the version mise already installed — but that is a behaviour change to how the job resolves its tooling and does not belong in a version bump. Left as a follow-up.

## Safety

`main` is clean under the newer linter, so this does not turn CI red on merge:

```text
$ mise exec -- golangci-lint --version
golangci-lint has version 2.13.2 built with go1.27.0

$ mise exec -- golangci-lint cache clean && mise exec -- golangci-lint run ./...
0 issues.
```

The SA1019 suppressions and gofumpt reformatting that 2.13.2 requires are already on `main` via #813.

## Known follow-up, not addressed here

2.13.2 warns that the `gofumpt.extra-rules` setting in `.golangci.yml` is deprecated in favour of `extra.group-params`. Migrating it is not a no-op — it changes formatting output and reflows several files — so it needs its own PR rather than riding along with a version bump.

## Test plan

- [x] `just ci-check` — passes
- [x] `mise exec -- golangci-lint run ./...` on `main` under 2.13.2 — 0 issues, cold cache
- [x] Confirmed `mise.toml` and `ci.yml` now name the same version
- [ ] CI green on this PR — the first run that actually exercises v2.13.2 upstream

## Note for the merge

This touches `.github/workflows/`, which the `Auto-queue` protection excludes, so it needs a manual merge rather than the queue.

## AI usage

Drafted with Claude Code (Opus 5). See [AI_POLICY.md](AI_POLICY.md).
