### PR TITLE
fix(sanitizer): stop rewriting DHCP TSIG metadata as hostnames

### DIFF
--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -553,6 +553,21 @@ First-match precedence has a second edge. A rule can match on field name and the
 - **One declining redactor is left on purpose.** The `username` rule still returns its input for system accounts via `isSystemUser`, so it consumes the match the same way. It is not a leak today: the values it declines (`root`, `nobody`, `www`) are ones moderate does not redact either, so monotonicity holds — verified by probe, not assumed. It becomes one the moment a value `isSystemUser` accepts is also something a moderate-mode rule would redact. Prefer a `FieldGuard` if you touch it.
 - **Adding a rule with generic patterns?** Patterns like `from`, `to`, or `subnet` match fields that have nothing to do with the rule. Give it a `FieldGuard`; do not test the value inside the `Redactor`.
 
+### 19.3 A Generic Field Pattern Sometimes Needs `FieldExclusions`, Not a `FieldGuard`
+
+§19.2 says to give a rule with generic patterns a `FieldGuard`. That advice has a limit: a `FieldGuard` only ever receives the **value**. When the value cannot distinguish the fields, only the field name can, and a guard is the wrong tool.
+
+The `hostname` rule lists `domain` as a `FieldPattern`, matched as a substring, so it claimed three DHCP dynamic-DNS TSIG metadata fields — `ddnsdomainkeyname`, `ddnsdomainkeyalgorithm`, and `ddnsdomainalgorithm`. A field-name match redacts unconditionally (§14.2), so in aggressive mode the literal `hmac-md5` the audit engine reads became `host-001.example.com`. The rule is `aggressiveOnly`, so moderate and minimal were correct and aggressive — the mode operators pick when sharing most widely — was the broken one.
+
+- **The obvious fix is wrong, and quietly so.** `FieldGuard: IsHostname` looks right and would have leaked every firewall hostname in the repo. `IsHostname` requires at least one dot (`TestIsHostname` pins `{"localhost", false}`), and **every** `<hostname>` value in `testdata/` is a single label: `firewall`, `OPNsense`, `pfSense`, `printer`, `fw-test`. The guard would decline on all of them, no later rule or detector would claim them, and aggressive mode would emit real hostnames verbatim.
+- **No value predicate can work here.** `hmac-md5` and `fw1` are both valid single DNS labels. The discriminating information is the field name, not the value shape.
+- **Fix:** `FieldExclusions []string` on `Rule`, honored in `ruleMatchesFieldName` — the shared chokepoint `ShouldRedactField` and `ShouldRedactFieldValue` both call, so the two lookups cannot drift. It skips the rule without consuming the match, exactly like `FieldGuard`. Matching is case-insensitive and anchored on the terminal path segment, so `dhcpd.lan.ddnsdomainkeyalgorithm` is excluded but `ddnsdomain` is not.
+- **The exclusion does not release hostnames.** It suppresses only the unconditional name-based claim; `ShouldRedactValue` still runs its value-detector pass, and the `hostname` rule's `ValueDetector` is in it. A hostname-shaped value stored in an excluded field is still redacted. `TestAggressiveMode_ExcludedTSIGFieldStillRedactsHostname` pins this.
+- **`ddnsdomainalgorithm` is the one you will miss.** It does not contain `ddnsdomainkey`, so the exact-match pattern that protects the other siblings from `private_key` does not cover it — and it is the most common of the three, appearing 71 times across the fixtures versus 4 for `ddnsdomainkeyalgorithm`. Grep the fixtures rather than trusting a bug report's field list.
+- **A fixture diff will look far bigger than the change.** `Mapper` numbers pseudonyms in encounter order, so releasing 71 values renumbers every later `host-NNN`. Mask the indices (`s/host-[0-9]+/host-N/`) before diffing, or you will be reading hundreds of lines of renumbering looking for the four that matter.
+- **Regression tests:** `TestRuleMatchesFieldName_FieldExclusions` (mechanism), `TestShouldRedactField_DDNSDomainKeySiblings` (all three fields, all three modes), `TestAggressiveMode_HostnameCoverageUnchanged` (the redaction this must not narrow).
+- **Do not "simplify" the exclusions into a `FieldGuard`.** The single-label hostname case above is why they are keyed on the field name.
+
 ## 20. pfSense Validator Injection
 
 ### 20.1 `SetValidator` Is Guarded by `sync.Once`

--- a/internal/sanitizer/rules.go
+++ b/internal/sanitizer/rules.go
@@ -197,7 +197,10 @@ func ruleExcludesFieldName(rule *Rule, fieldName string) bool {
 		return false
 	}
 
-	segment := terminalSegment(strings.ToLower(fieldName))
+	// No ToLower: terminalSegment splits on byte positions and EqualFold
+	// compares case-insensitively, so lowercasing here would allocate for
+	// nothing on every field name the rule matched.
+	segment := terminalSegment(fieldName)
 
 	return slices.ContainsFunc(rule.FieldExclusions, func(excluded string) bool {
 		return strings.EqualFold(segment, excluded)
@@ -293,17 +296,20 @@ func fieldNameMatches(fieldName, pattern string) bool {
 	return strings.Contains(lowerField, pattern)
 }
 
-// terminalSegment returns the last dot-delimited segment of a lowercased field
-// path, dropping any slice index the reflection path appends ("apikeys[0]"
-// becomes "apikeys").
-func terminalSegment(lowerField string) string {
-	if dot := strings.LastIndexByte(lowerField, '.'); dot >= 0 {
-		lowerField = lowerField[dot+1:]
+// terminalSegment returns the last dot-delimited segment of a field path,
+// dropping any slice index the reflection path appends ("apikeys[0]" becomes
+// "apikeys"). It splits on byte positions only, so it preserves the case it is
+// given: fieldNameMatches passes an already-lowercased path because it then
+// compares with strings.Contains, while ruleExcludesFieldName passes the raw
+// path and compares with strings.EqualFold.
+func terminalSegment(field string) string {
+	if dot := strings.LastIndexByte(field, '.'); dot >= 0 {
+		field = field[dot+1:]
 	}
-	if bracket := strings.IndexByte(lowerField, '['); bracket >= 0 {
-		lowerField = lowerField[:bracket]
+	if bracket := strings.IndexByte(field, '['); bracket >= 0 {
+		field = field[:bracket]
 	}
-	return lowerField
+	return field
 }
 
 // builtinRules returns the default set of redaction rules used by the sanitizer package.

--- a/internal/sanitizer/rules.go
+++ b/internal/sanitizer/rules.go
@@ -60,13 +60,12 @@ type Rule struct {
 	// FieldExclusions names fields this rule must never claim on a
 	// FieldPatterns match, compared case-insensitively against the field
 	// path's terminal segment. It is the field-name counterpart to
-	// FieldGuard: a generic pattern such as "domain" can match a field whose
-	// value has nothing to do with the rule, and sometimes only the field
-	// name distinguishes them -- a TSIG algorithm name and a single-label
-	// hostname are both valid DNS labels, so no value predicate separates
-	// them. Like FieldGuard it skips the rule without consuming the match,
-	// so a later rule or the value-detector pass can still claim the value.
-	// See GOTCHAS.md section 19.3.
+	// FieldGuard, for the case FieldGuard cannot express: a guard sees only
+	// the value, so when two fields carry indistinguishable values and only
+	// their names differ, the exclusion has to key on the name. Like
+	// FieldGuard it skips the rule without consuming the match, so a later
+	// rule or the value-detector pass can still claim the value.
+	// See GOTCHAS.md section 19.3 for the case that motivated it.
 	FieldExclusions []string
 	// Redactor performs the actual redaction using the mapper.
 	Redactor func(mapper *Mapper, fieldName, value string) string
@@ -175,13 +174,12 @@ func (e *RuleEngine) ShouldRedactFieldValue(fieldName, value string) (bool, Rule
 // fieldName and the rule does not exclude that field. Shared so the guarded
 // and unguarded lookups cannot drift.
 func ruleMatchesFieldName(rule *Rule, fieldName string) bool {
-	if ruleExcludesFieldName(rule, fieldName) {
-		return false
-	}
-
 	for _, pattern := range rule.FieldPatterns {
 		if fieldNameMatches(fieldName, pattern) {
-			return true
+			// Exclusions are rule-level, so one check on the first matching
+			// pattern settles it. Checking here rather than up front keeps the
+			// cost off every field name the rule was never going to claim.
+			return !ruleExcludesFieldName(rule, fieldName)
 		}
 	}
 
@@ -200,13 +198,10 @@ func ruleExcludesFieldName(rule *Rule, fieldName string) bool {
 	}
 
 	segment := terminalSegment(strings.ToLower(fieldName))
-	for _, excluded := range rule.FieldExclusions {
-		if strings.EqualFold(segment, excluded) {
-			return true
-		}
-	}
 
-	return false
+	return slices.ContainsFunc(rule.FieldExclusions, func(excluded string) bool {
+		return strings.EqualFold(segment, excluded)
+	})
 }
 
 // ShouldRedactValue determines if a value should be redacted based on its content.

--- a/internal/sanitizer/rules.go
+++ b/internal/sanitizer/rules.go
@@ -57,6 +57,17 @@ type Rule struct {
 	// silently suppress every later rule -- see GOTCHAS.md section 19.2.
 	// The guard must not allocate: it runs on values the rule may not redact.
 	FieldGuard func(value string) bool
+	// FieldExclusions names fields this rule must never claim on a
+	// FieldPatterns match, compared case-insensitively against the field
+	// path's terminal segment. It is the field-name counterpart to
+	// FieldGuard: a generic pattern such as "domain" can match a field whose
+	// value has nothing to do with the rule, and sometimes only the field
+	// name distinguishes them -- a TSIG algorithm name and a single-label
+	// hostname are both valid DNS labels, so no value predicate separates
+	// them. Like FieldGuard it skips the rule without consuming the match,
+	// so a later rule or the value-detector pass can still claim the value.
+	// See GOTCHAS.md section 19.3.
+	FieldExclusions []string
 	// Redactor performs the actual redaction using the mapper.
 	Redactor func(mapper *Mapper, fieldName, value string) string
 }
@@ -161,10 +172,36 @@ func (e *RuleEngine) ShouldRedactFieldValue(fieldName, value string) (bool, Rule
 }
 
 // ruleMatchesFieldName reports whether any of rule's FieldPatterns matches
-// fieldName. Shared so the guarded and unguarded lookups cannot drift.
+// fieldName and the rule does not exclude that field. Shared so the guarded
+// and unguarded lookups cannot drift.
 func ruleMatchesFieldName(rule *Rule, fieldName string) bool {
+	if ruleExcludesFieldName(rule, fieldName) {
+		return false
+	}
+
 	for _, pattern := range rule.FieldPatterns {
 		if fieldNameMatches(fieldName, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ruleExcludesFieldName reports whether fieldName is one of rule's
+// FieldExclusions. The comparison is case-insensitive and anchored on the
+// terminal path segment -- the same anchoring fieldNameMatches applies to
+// exactMatchPatterns -- because the engine looks up both bare field names and
+// full dotted paths. Unlike FieldPatterns, exclusions are not pre-lowercased
+// at cache time, so a rule may declare them in any case.
+func ruleExcludesFieldName(rule *Rule, fieldName string) bool {
+	if len(rule.FieldExclusions) == 0 {
+		return false
+	}
+
+	segment := terminalSegment(strings.ToLower(fieldName))
+	for _, excluded := range rule.FieldExclusions {
+		if strings.EqualFold(segment, excluded) {
 			return true
 		}
 	}
@@ -530,6 +567,20 @@ func builtinRules() []Rule {
 			Modes:       aggressiveOnly,
 			FieldPatterns: []string{
 				"hostname", "domain", "althostnames", "hostnames",
+			},
+			// DHCP dynamic-DNS TSIG metadata. All three names contain
+			// "domain", so the substring pattern above claimed them, and a
+			// field-name match redacts unconditionally (GOTCHAS 14.2) --
+			// rewriting the literal "hmac-md5" the audit engine reads into a
+			// pseudonymised host in aggressive mode, which moderate and
+			// minimal left alone. A FieldGuard cannot separate these: the
+			// algorithm name and a single-label hostname such as "firewall"
+			// are both valid DNS labels, so the field name is the only
+			// discriminating information. A genuinely hostname-shaped value
+			// in one of these fields is still redacted, via the
+			// value-detector pass.
+			FieldExclusions: []string{
+				"ddnsdomainkeyname", "ddnsdomainkeyalgorithm", "ddnsdomainalgorithm",
 			},
 			ValueDetector: func(value string) bool {
 				// Don't match emails as hostnames

--- a/internal/sanitizer/rules_credential_gaps_test.go
+++ b/internal/sanitizer/rules_credential_gaps_test.go
@@ -122,18 +122,25 @@ func TestRedact_DDNSDomainKey(t *testing.T) {
 
 // TestShouldRedactField_DDNSDomainKeySiblings guards the reason ddnsdomainkey
 // is an exact-match pattern. As a substring it would also swallow its
-// siblings, redacting the literal "hmac-md5" the audit engine reads. The
-// siblings may still match other rules in aggressive mode (hostname claims
-// anything containing "domain"), so this asserts only that private_key never
-// takes them.
+// siblings, redacting the literal "hmac-md5" the audit engine reads.
+//
+// It also pins the fix for the hostname rule claiming those same siblings.
+// All three sibling names contain "domain", which the hostname rule lists as
+// a FieldPattern and matches as a substring, and a field-name match redacts
+// unconditionally (GOTCHAS 14.2). In aggressive mode that turned the literal
+// TSIG algorithm name into a pseudonymised host. The hostname rule now
+// carries FieldExclusions for these fields, so the value survives in every
+// mode.
 func TestShouldRedactField_DDNSDomainKeySiblings(t *testing.T) {
 	t.Parallel()
 
 	siblings := []string{
 		"ddnsdomainkeyname",
 		"ddnsdomainkeyalgorithm",
+		"ddnsdomainalgorithm",
 		"dhcpd.lan.ddnsdomainkeyname",
 		"dhcpd.lan.ddnsdomainkeyalgorithm",
+		"dhcpd.lan.ddnsdomainalgorithm",
 	}
 
 	for _, mode := range []Mode{ModeAggressive, ModeModerate, ModeMinimal} {
@@ -147,21 +154,12 @@ func TestShouldRedactField_DDNSDomainKeySiblings(t *testing.T) {
 					t.Errorf("ShouldRedactField(%q) matched private_key, want the exact-match guard to hold", field)
 				}
 
-				// Assert on the emitted value, not just the rule name. The
-				// exact-match guard is what this test is for, but a weaker
-				// assertion would also pass if some other rule rewrote the
-				// value, which is exactly what happens in aggressive mode:
-				// both siblings contain "domain" and so match the hostname
-				// rule, and a field-name match redacts unconditionally
-				// (GOTCHAS 14.2), turning the literal algorithm name into a
-				// pseudonymised host. That is pre-existing behaviour of the
-				// hostname rule rather than anything this change introduces,
-				// so it is pinned here rather than altered.
+				// Assert on the emitted value, not just the rule name. A
+				// weaker assertion would also pass if some other rule rewrote
+				// the value, which is what the hostname rule used to do in
+				// aggressive mode. The value must now survive in every mode.
 				got := engine.Redact(field, siblingProbeValue)
 				want := siblingProbeValue
-				if mode == ModeAggressive {
-					want = "host-001.example.com"
-				}
 
 				if got != want {
 					t.Errorf("Redact(%q, %q) in %s = %q, want %q",
@@ -238,6 +236,74 @@ func TestFieldNameMatches_TerminalSegmentAnchoring(t *testing.T) {
 			t.Parallel()
 			if got := fieldNameMatches(tt.field, tt.pattern); got != tt.want {
 				t.Errorf("fieldNameMatches(%q, %q) = %v, want %v", tt.field, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAggressiveMode_HostnameCoverageUnchanged pins the redaction the TSIG
+// field exclusions must not narrow. Every <hostname> value in testdata is a
+// single label with no dot ("firewall", "OPNsense"), and IsHostname requires a
+// dot, so a value-shaped guard on the hostname rule would have released all of
+// them in aggressive mode. The exclusions are keyed on the field name for
+// exactly that reason.
+func TestAggressiveMode_HostnameCoverageUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		field string
+		value string
+	}{
+		{"hostname", "firewall"},
+		{"hostname", "OPNsense"},
+		{"hostname", "fw.example.com"},
+		{"domain", "example.com"},
+		{"domain", "localdomain"},
+		{"ddnsdomain", "dyn.example.com"},
+		{"ddnsdomainprimary", "ns1.example.com"},
+		{"domainsearchlist", "corp.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field+"_"+tt.value, func(t *testing.T) {
+			t.Parallel()
+
+			engine := NewRuleEngine(ModeAggressive)
+
+			got := engine.Redact(tt.field, tt.value)
+			if got != expectedMappedHostname1 {
+				t.Errorf("Redact(%q, %q) in aggressive = %q, want %q",
+					tt.field, tt.value, got, expectedMappedHostname1)
+			}
+		})
+	}
+}
+
+// TestAggressiveMode_ExcludedTSIGFieldStillRedactsHostname pins the residual
+// safety net. A field exclusion suppresses only the unconditional field-name
+// claim; ShouldRedactValue still runs its value-detector pass afterward, and
+// the hostname rule's ValueDetector is in it. So the exclusions release TSIG
+// algorithm names without releasing a hostname an operator stored in one of
+// these fields.
+func TestAggressiveMode_ExcludedTSIGFieldStillRedactsHostname(t *testing.T) {
+	t.Parallel()
+
+	excluded := []string{
+		"ddnsdomainkeyname",
+		"ddnsdomainkeyalgorithm",
+		"ddnsdomainalgorithm",
+	}
+
+	for _, field := range excluded {
+		t.Run(field, func(t *testing.T) {
+			t.Parallel()
+
+			engine := NewRuleEngine(ModeAggressive)
+
+			got := engine.Redact(field, "tsig-key.internal.example.com")
+			if got != expectedMappedHostname1 {
+				t.Errorf("Redact(%q, hostname-shaped value) in aggressive = %q, want %q",
+					field, got, expectedMappedHostname1)
 			}
 		})
 	}

--- a/internal/sanitizer/rules_fieldpattern_test.go
+++ b/internal/sanitizer/rules_fieldpattern_test.go
@@ -594,6 +594,12 @@ func TestRuleMatchesFieldName_FieldExclusions(t *testing.T) {
 		{"a mixed-case field is excluded", []string{"ddnsdomainkeyalgorithm"}, "DDNSDomainKeyAlgorithm", false},
 		{"a mixed-case exclusion still excludes", []string{"DDNSDomainKeyAlgorithm"}, "ddnsdomainkeyalgorithm", false},
 		{
+			"a mixed-case dotted path is excluded",
+			[]string{"ddnsdomainkeyalgorithm"},
+			"DHCPD.LAN.DDNSDomainKeyAlgorithm",
+			false,
+		},
+		{
 			"a substring of the terminal segment does not suppress",
 			[]string{"ddnsdomain"},
 			"ddnsdomainkeyalgorithm",

--- a/internal/sanitizer/rules_fieldpattern_test.go
+++ b/internal/sanitizer/rules_fieldpattern_test.go
@@ -564,3 +564,58 @@ func TestShouldRedactField_OTPSeed(t *testing.T) {
 		})
 	}
 }
+
+// TestRuleMatchesFieldName_FieldExclusions covers the field-name counterpart to
+// FieldGuard: a rule names fields it must never claim even when one of its
+// FieldPatterns matches. FieldGuard cannot express this because it only ever
+// sees the value. See GOTCHAS.md section 19.3.
+func TestRuleMatchesFieldName_FieldExclusions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		exclusions []string
+		field      string
+		want       bool
+	}{
+		{"no exclusions leaves the match intact", nil, "ddnsdomainkeyalgorithm", true},
+		{
+			"exclusion equal to the field suppresses the match",
+			[]string{"ddnsdomainkeyalgorithm"},
+			"ddnsdomainkeyalgorithm",
+			false,
+		},
+		{
+			"exclusion anchors on the terminal segment",
+			[]string{"ddnsdomainkeyalgorithm"},
+			"dhcpd.lan.ddnsdomainkeyalgorithm",
+			false,
+		},
+		{"a mixed-case field is excluded", []string{"ddnsdomainkeyalgorithm"}, "DDNSDomainKeyAlgorithm", false},
+		{"a mixed-case exclusion still excludes", []string{"DDNSDomainKeyAlgorithm"}, "ddnsdomainkeyalgorithm", false},
+		{
+			"a substring of the terminal segment does not suppress",
+			[]string{"ddnsdomain"},
+			"ddnsdomainkeyalgorithm",
+			true,
+		},
+		{"an unrelated exclusion leaves the match intact", []string{"unrelated"}, "ddnsdomainkeyalgorithm", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rule := Rule{
+				Name:            "test_rule",
+				FieldPatterns:   []string{"domain"},
+				FieldExclusions: tt.exclusions,
+			}
+
+			if got := ruleMatchesFieldName(&rule, tt.field); got != tt.want {
+				t.Errorf("ruleMatchesFieldName(%q) with exclusions %v = %v, want %v",
+					tt.field, tt.exclusions, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

The sanitizer's `hostname` rule lists `domain` as a `FieldPattern`, matched as a substring. Three DHCP dynamic-DNS TSIG metadata fields contain that substring and were claimed by the rule:

- `ddnsdomainkeyname`
- `ddnsdomainkeyalgorithm`
- `ddnsdomainalgorithm`

A field-name match redacts unconditionally, so in aggressive mode the literal `hmac-md5` the audit engine reads was rewritten to `host-001.example.com`. Moderate and minimal were unaffected, which left the highest-privacy mode as the only one corrupting audit-relevant metadata.

`Rule` gains `FieldExclusions []string`, honored in `ruleMatchesFieldName` — the shared chokepoint that both `ShouldRedactField` and `ShouldRedactFieldValue` call, so the guarded and unguarded lookups cannot drift. Matching is case-insensitive and anchored on the terminal path segment, so `dhcpd.lan.ddnsdomainkeyalgorithm` is excluded while `ddnsdomain` is not. The `hostname` rule declares the three fields above. `GOTCHAS.md` gains section 19.3.

## Why

Fixes #818.

The obvious fix — `FieldGuard: IsHostname` on the `hostname` rule — is wrong in a way that leaks. `IsHostname` requires at least one dot (pinned by `TestIsHostname` with `{"localhost", false}`), and every `<hostname>` value in `testdata/` is a single label: `firewall`, `OPNsense`, `pfSense`, `printer`, `test-firewall`. A value guard would decline on all of them, no later rule or detector would claim them, and aggressive mode would emit real firewall hostnames verbatim.

No value predicate can separate these: `hmac-md5` and `fw1` are both valid single DNS labels. The field name is the only discriminating information, and `FieldGuard` never sees it.

The exclusion suppresses only the unconditional name-based claim. `ShouldRedactValue` still runs its value-detector pass, and the `hostname` rule's `ValueDetector` is in it, so a hostname-shaped value stored in one of these fields is still redacted.

`ddnsdomainalgorithm` is not named in the issue. It does not contain `ddnsdomainkey`, so the exact-match pattern protecting the other two siblings does not cover it — and it is the most common of the three, appearing 71 times across the fixtures against 4 for `ddnsdomainkeyalgorithm`.

## How this was verified

```bash
just ci-check
go test ./internal/sanitizer/...
```

Byte-level sweep over all 13 fixtures in all 3 modes, against a binary built from the parent commit:

```bash
go build -o /tmp/opndossier-after .
for f in $(find testdata -name '*.xml'); do
  for m in aggressive moderate minimal; do
    /tmp/opndossier-after sanitize "$f" --mode "$m" > "/tmp/after/$(echo "$f" | tr / _).$m"
  done
done
diff -r /tmp/before /tmp/after
```

The mapper numbers pseudonyms in encounter order, so releasing 71 values renumbers later `host-NNN` entries. After masking those indices (`sed -E 's/host-[0-9]+/host-N/g'`), the only remaining differences are the 75 TSIG values that now survive: 71 `<ddnsdomainalgorithm>` and 4 `<ddnsdomainkeyalgorithm>`. No other element changed, and no previously-redacted hostname is emitted.

Tests added or updated:

- `TestShouldRedactField_DDNSDomainKeySiblings` — re-pointed from asserting the rewrite to asserting the value survives; extended to all three fields, bare and dotted, in all three modes.
- `TestRuleMatchesFieldName_FieldExclusions` — the mechanism: terminal-segment anchoring, case-insensitivity, and that a substring of the segment does not suppress a match.
- `TestAggressiveMode_HostnameCoverageUnchanged` — the redaction this must not narrow, including single-label `firewall` and `OPNsense`, plus `domain`, `ddnsdomain`, `ddnsdomainprimary` and `domainsearchlist`.
- `TestAggressiveMode_ExcludedTSIGFieldStillRedactsHostname` — a hostname-shaped value in an excluded field is still redacted.

## Note for reviewers

In aggressive mode `ddnsdomainkeyname` now emits its value when that value is not hostname-shaped. A TSIG key name is operator-chosen and can carry organisation-identifying text. This is the behaviour #818 asks for, and the two algorithm fields carry no such risk — flagging it so the narrowing is a conscious trade-off rather than an accident.

## AI disclosure

Used Claude Code (`Claude Opus 5 (1M context)`) to diagnose the field-matching cause and draft the fix, tests, and documentation. All code reviewed locally and via CI before push. Followed process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
