### PR TITLE
docs: refresh solutions store against the current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This file provides AI coding assistants with project context. All substantive do
 - **[Architecture](docs/development/architecture.md)** — System design, component interactions, deployment patterns
 - **[Known Gotchas](GOTCHAS.md)** — Non-obvious behaviors, common pitfalls, hard-won lessons
 - **[Plugin Development](docs/development/plugin-development.md)** — Compliance plugin and device parser development
-- **[Solutions](docs/solutions/)** — Documented problem solutions for searchable future reference
+- **[Solutions](docs/solutions/)** — Documented problem solutions for searchable future reference, filed by category (architecture-issues, logic-errors, runtime-errors, workflow-issues, performance-issues, conventions) with YAML frontmatter (`component`, `tags`, `problem_type`); relevant when implementing or debugging in an area one covers
 - **[Concepts](CONCEPTS.md)** — Shared domain vocabulary (entities, named processes, status concepts); relevant when orienting to the codebase or discussing domain concepts
 
 ## Agent-Specific Rules

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -34,10 +34,18 @@ The impact-and-context framing attached to a red-mode exposure finding: why an e
 
 ## Device model
 
+### Common device
+
+The vendor-neutral representation every device parser produces: one firewall's configuration expressed in a single shared shape, so that analysis, compliance checks, diffing, and every output format work against one model rather than against each vendor's own config dialect. Adding support for a new platform means writing a parser that populates this model, not teaching every downstream consumer a new schema.
+
+A Common device is the unit of analysis — one parsed configuration file normally yields exactly one.
+
 ### Named-object reference layer
 
-Planned: an additive registry (`NamedObjects`) and reference concept (`ObjectRef`) on `CommonDevice` that would let a device parser preserve object-oriented config as named object definitions plus rule-level references to them, alongside the existing resolved-inline-value fields. Not yet implemented — `CommonDevice` does not currently expose these fields. The design intent is for resolved values to stay always populated so existing pf-family checks keep firing unmodified, with the reference layer optional and empty for devices (OPNsense, pfSense) that have no named-object concept, unlocking reference-integrity checks like dangling-object detection without a schema rewrite.
+The registry of named object definitions a device declares, plus the rule-level references pointing at them, carried on a Common device alongside its resolved inline values. It lets a parser preserve object-oriented configuration as definitions-and-references rather than flattening it away.
+
+Resolved values stay populated whether or not the layer is present, so checks written against addresses and ports keep firing unmodified; the layer is simply empty for platforms that have no named-object concept. Its presence is what makes reference-integrity questions expressible at all — whether a reference points at nothing, and whether a defined object is reachable from any policy.
 
 ### DeviceBundle
 
-The planned container for a config file that yields more than one `CommonDevice` from a single parse — the deferred FortiGate VDOM case, where each VDOM (plus the global scope) becomes its own device rather than being merged into one. Not yet implemented: today's parsers are single-`CommonDevice`-per-file only, and a VDOM-bearing FortiGate config is detected and warned rather than expanded into a DeviceBundle.
+The planned container for a config file that yields more than one Common device from a single parse — the deferred FortiGate VDOM case, where each VDOM (plus the global scope) becomes its own device rather than being merged into one. Not yet implemented: today's parsers are single-device-per-file only, and a VDOM-bearing FortiGate config is detected and warned rather than expanded into a DeviceBundle.

--- a/docs/solutions/architecture-issues/file-split-refactor-gotchas.md
+++ b/docs/solutions/architecture-issues/file-split-refactor-gotchas.md
@@ -4,7 +4,7 @@ category: architecture-issues
 date: 2026-03-18
 tags: [refactoring, file-split, pre-commit, testing, validator]
 related_issues: ['#319', '#415']
-components: [internal/validator, internal/processor]
+components: [internal/validator]
 ---
 
 # File-Split Refactoring: Pre-commit Hooks and Test Breakage

--- a/docs/solutions/architecture-issues/format-dispatch-centralization-registry-pattern.md
+++ b/docs/solutions/architecture-issues/format-dispatch-centralization-registry-pattern.md
@@ -40,7 +40,7 @@ Format dispatch logic for output formats (markdown, json, yaml, text, html) was 
 - `internal/converter/options.go` -- Format.Validate switch
 - `internal/config/validation.go` -- ValidFormats list
 - `cmd/shared_flags.go` -- shell completion list
-- `internal/processor/processor.go` -- Transform switch (no alias resolution)
+- `internal/processor/processor.go` -- Transform switch (no alias resolution); this package was later deleted entirely in #777, so only the remaining locations are greppable today
 
 Adding a new format required coordinating updates across all locations. Missing one caused silent inconsistencies -- a format valid in one location might be rejected or produce wrong output elsewhere.
 
@@ -113,12 +113,10 @@ When a struct has mutable state (like MarkdownBuilder), create a fresh instance 
 - [ ] Shell completions derive from `DefaultRegistry.ValidFormats()`
 - [ ] `Format.Validate()` delegates to registry
 - [ ] `config.ValidFormats` derives from registry with `slices.Clone()`
-- [ ] `processor.Transform()` resolves aliases via `Canonical()`
 - [ ] `go test -race ./internal/converter/...` passes
 - [ ] `just ci-check` passes
 
 ## Related Documentation
 
-- [AGENTS.md section 5.9b](https://github.com/EvilBit-Labs/opnDossier/blob/main/AGENTS.md) -- FormatRegistry Pattern documentation
-- [architecture.md](../../development/architecture.md) -- FormatRegistry Integration section
+- [pipelines.md](../../development/architecture/pipelines.md) -- the FormatRegistry dispatch layer, with the export-stage sequence diagram
 - [documentation-code-drift-interface-refactoring.md](../logic-errors/documentation-code-drift-interface-refactoring.md) -- documentation accuracy guidelines

--- a/docs/solutions/conventions/pr-and-commit-message-content-standard-2026-05-04.md
+++ b/docs/solutions/conventions/pr-and-commit-message-content-standard-2026-05-04.md
@@ -71,7 +71,7 @@ If AI assistance was used in producing the diff, this project's [`AI_POLICY.md`]
 ```markdown
 ## AI disclosure
 
-Used Claude Code (`<model name>`) for <one-line description of where AI assisted>. All code reviewed locally and via CI before push. Followed process per [`AI_POLICY.md`](../blob/main/AI_POLICY.md).
+Used Claude Code (`<model name>`) for <one-line description of where AI assisted>. All code reviewed locally and via CI before push. Followed process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
 ```
 
 The disclosure satisfies the policy requirement in two short lines. Do not expand it into a skill inventory, a list of automated reviewers, or a description of the agent's workflow — that is the same chronicling problem moved into a different section.
@@ -163,7 +163,7 @@ push. Run artifacts retained at `/tmp/compound-engineering/...`.
 
 Used Claude Code (`Claude Opus 4.7 (1M Context)`) for the implementation and
 PR description. All code reviewed locally and via CI before push. Followed
-process per [`AI_POLICY.md`](../blob/main/AI_POLICY.md).
+process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
 ```
 
 The minimal form satisfies the disclosure requirement in [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md) while staying out of the way of the actual change description.
@@ -197,7 +197,7 @@ A PR body that meets this standard tends to look like:
 ## AI disclosure
 
 Used Claude Code (`<model>`) for <scope>. All code reviewed locally and via
-CI before push. Followed process per [`AI_POLICY.md`](../blob/main/AI_POLICY.md).
+CI before push. Followed process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
 
 ## Refs
 

--- a/docs/solutions/logic-errors/documentation-code-drift-interface-refactoring.md
+++ b/docs/solutions/logic-errors/documentation-code-drift-interface-refactoring.md
@@ -15,7 +15,7 @@ tags:
   - prose-verification
   - automated-review-gap
   - second-opinion
-component: converter/builder, processor
+component: converter/builder
 severity: medium
 symptoms:
   - Documentation lists method names that do not exist in code
@@ -212,6 +212,8 @@ Before merging PRs that touch docs, AGENTS.md, GOTCHAS.md, or Mermaid diagrams:
 - [ ] Code paths described in docs have corresponding test cases
 
 ## Recurrence: Concurrency-Invariant Prose (2026-05-03)
+
+> The `internal/processor` package cited throughout this section was deleted in #777 (packages outside the binary dependency closure). The file and line references below are preserved as the record of what the review actually examined; they no longer resolve on `main`. The drift pattern and the review technique are what carry forward.
 
 The same drift pattern recurred on a different surface — concurrency invariants rather than interface methods — in [PR #598](https://github.com/EvilBit-Labs/opnDossier/pull/598) (`perf(processor): remove CoreProcessor mutex serialization`, squash-merged as commit `433bad6`). The mutex removal was correct and benchmarked clean (~2.24-2.57x throughput improvement). The follow-up doc commit on that PR (collapsed into `433bad6` by the squash-merge, so no longer addressable as a standalone SHA) contained three factual errors that a multi-persona automated review (correctness, testing, maintainability, project-standards, performance, reliability) passed without challenge:
 

--- a/docs/solutions/performance-issues/recursive-alias-resolution-dag-blowup.md
+++ b/docs/solutions/performance-issues/recursive-alias-resolution-dag-blowup.md
@@ -21,7 +21,7 @@ related_docs: []
 
 # Memoizing Recursive Graph Resolution Must Also Bound Output Size
 
-> **Fix status:** Introduced by [PR #696](https://github.com/EvilBit-Labs/opnDossier/pull/696) (firewall rule shadowing detection), unmerged as of this writing. The cited file `pkg/model/named_objects.go` does not exist on `main` yet — it is added by that PR. The behavior described below reflects that PR's `NamedObjects.Resolve` / `resolveNode` implementation.
+> **Fix status:** Merged. Introduced by [PR #696](https://github.com/EvilBit-Labs/opnDossier/pull/696) (firewall rule shadowing detection). `pkg/model/named_objects.go` is on `main` and carries all three mechanisms described below: `maxAliasDepth` (16), the per-`Resolve` `memo`, and `dedupeSorted` applied at every node as well as at the top.
 
 ## Problem
 

--- a/docs/solutions/runtime-errors/plugin-panic-recovery-audit-runchecks.md
+++ b/docs/solutions/runtime-errors/plugin-panic-recovery-audit-runchecks.md
@@ -61,7 +61,7 @@ The immediately-invoked function literal creates a deferred recovery scope isola
 ### Key Design Decisions
 
 1. **Logger parameter uses `*logging.Logger`** -- matches the project's charmbracelet/log-based logging, ensuring panic recovery logs respect the application's configured output format, level, and destination. A nil guard defaults to a fallback logger so callers can never trigger a secondary panic on the recovery path.
-2. **Stack trace included via `runtime/debug.Stack()`** -- matches the pattern in `internal/processor/processor.go`, giving actionable debugging information for misbehaving plugins (especially dynamic `.so` files).
+2. **Stack trace included via `runtime/debug.Stack()`** -- giving actionable debugging information for misbehaving plugins (especially dynamic `.so` files).
 3. **Panicked plugins retained in results with safe defaults** -- a `panicked` flag gates the post-recovery path. When set, safe defaults (`pluginName`, `Version: "unknown (panicked)"`, empty compliance map) are populated and the loop `continue`s, skipping method calls (`Name()`, `Description()`, `GetControls()`) on the potentially corrupt plugin. Downstream consumers can see the plugin was requested and evaluated. See GOTCHAS.md SS2.2.
 4. **Post-recovery method calls avoided** -- after a panic, the plugin's internal state may be corrupt. Calling `p.Name()`, `p.GetControls()`, etc. could trigger a secondary unrecovered panic. The recovery path uses only the `pluginName` string already in scope from the loop variable.
 

--- a/docs/solutions/workflow-issues/ci-runs-on-pull-request-not-feature-branch-push.md
+++ b/docs/solutions/workflow-issues/ci-runs-on-pull-request-not-feature-branch-push.md
@@ -34,17 +34,20 @@ The local `just ci-check` recipe is the pre-push gate; remote CI is a **PR-time*
 
 Trigger map for the workflows in `.github/workflows/` (as of this writing):
 
-| Workflow        | Triggers on                                                           |
-| --------------- | --------------------------------------------------------------------- |
-| `ci.yml`        | `push: main`, `pull_request`                                          |
-| `security.yml`  | `push: main`, `pull_request`, weekly schedule                         |
-| `docs.yml`      | `push: main`                                                          |
-| `go-deps.yml`   | `push: main`                                                          |
-| `scorecard.yml` | `push: main`, `branch_protection_rule`, schedule, `workflow_dispatch` |
-| `release.yml`   | `push` tags `v*`, `workflow_dispatch`                                 |
-| `sbom.yml`      | schedule, `workflow_dispatch`                                         |
+| Workflow                  | Triggers on                                                                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `ci.yml`                  | `push: main`, `pull_request`                                                                                                 |
+| `security.yml`            | `push: main`, `pull_request`, weekly schedule                                                                                |
+| `docs.yml`                | `push: main`, `pull_request` (paths: `docs/**`, `mkdocs.yml`, `requirements.txt`, `mise.toml`, `.github/workflows/docs.yml`) |
+| `go-deps.yml`             | `push: main`                                                                                                                 |
+| `scorecard.yml`           | `push: main`, `branch_protection_rule`, schedule, `workflow_dispatch`                                                        |
+| `release.yml`             | `push` tags `v*`, `workflow_dispatch`                                                                                        |
+| `sbom.yml`                | schedule, `workflow_dispatch`                                                                                                |
+| `copilot-setup-steps.yml` | `workflow_dispatch`, `push` and `pull_request` (paths: its own file only)                                                    |
 
-Practical consequence: on a feature branch, **only a PR (or merging to `main`) runs Actions.** Doc/metadata-only branches still get the full `ci.yml` + `security.yml` matrix once a PR is open, because neither has a path filter.
+Practical consequence: on a feature branch, **only a PR (or merging to `main`) runs Actions** — with one narrow exception: `copilot-setup-steps.yml` has an unrestricted `push` trigger filtered to its own file, so a branch push that edits that one workflow does fire it. Nothing else does.
+
+Doc/metadata-only branches still get the full `ci.yml` + `security.yml` matrix once a PR is open, because neither has a path filter; a PR touching `docs/**` additionally fires `docs.yml`, which does.
 
 ## Why This Matters
 

--- a/docs/solutions/workflow-issues/dependency-bump-markdown-output-whitespace-drift.md
+++ b/docs/solutions/workflow-issues/dependency-bump-markdown-output-whitespace-drift.md
@@ -4,7 +4,7 @@ category: workflow-issues
 date: '2026-08-21'
 module: internal/converter
 problem_type: workflow_issue
-component: converter/builder, processor
+component: converter/builder
 severity: medium
 tags:
   - dependency-update
@@ -31,7 +31,7 @@ related_docs:
 
 ## Context
 
-`github.com/nao1215/markdown` (v0.13.0 to v1.0.0, dependabot PR #770) is the library `internal/converter/builder` and `internal/processor/report_markdown.go` use to construct every markdown-format report opnDossier generates. 21 Go files reference the package (12 non-test import sites, plus test files); it is not an incidental dependency — it owns the literal bytes of a primary output format.
+`github.com/nao1215/markdown` (v0.13.0 to v1.0.0, dependabot PR #770) is the library `internal/converter/builder` (and, at the time, `internal/processor/report_markdown.go`) uses to construct every markdown-format report opnDossier generates. 21 Go files referenced the package (12 non-test import sites, plus test files); it is not an incidental dependency — it owns the literal bytes of a primary output format.
 
 The bump touched only `go.mod` and `go.sum`. `go build`, `go vet`, and every package except one passed unchanged. `TestGolden_ProgrammaticReportGeneration` (`internal/converter/golden_test.go`) failed all six subtests — the only failure in the repo.
 
@@ -42,7 +42,9 @@ Two upstream changelog claims looked, at a skim, like they might affect this rep
 - The v1.0.0 CHANGELOG lists "line endings on Windows" among its fixes. Reading the library's own `lf.go` in the module cache (`$(go env GOMODCACHE)/github.com/nao1215/markdown@v1.0.0/internal/lf.go` — a dependency path, not a repo path) shows the fix was a testability refactor — `LineFeed()` now delegates to an unexported `lineFeed(goos string)` so both branches can be tested regardless of the host OS — not a behavior change. `lineFeed` still returns `"\r\n"` when `goos == "windows"` and `"\n"` otherwise, identical to v0.13.0. `internal/converter/builder/lineendings.go`'s `renderMarkdown` (`formatters.NormalizeToLF(md.String())`) and the invariant documented in `GOTCHAS.md` section 10.4 are therefore still load-bearing and unaffected.
 - The v1.0.0 CHANGELOG's "Upgrading from v0.13.0" section states every regenerated document now ends with a trailing line ending (MD047 compliance), achieved via the writer-flush path. opnDossier extracts output via `md.String()` directly rather than through that writer-flush path, so this repo's generated reports were verified byte-identical at the tail before and after the bump — still no trailing LF.
 
-A gap surfaced by tracing every call site: `internal/processor/report_markdown.go` builds markdown independently of `internal/converter/builder` (the divergence `GOTCHAS.md` section 10.4 already names — both had to be given the `NormalizeToLF` treatment separately for the same reason). It has no golden fixture at all under `internal/processor`, so its output shifted with this same bump and nothing in the test suite would catch it either way.
+A gap surfaced by tracing every call site: `internal/processor/report_markdown.go` built markdown independently of `internal/converter/builder` (the divergence `GOTCHAS.md` section 10.4 already names — both had to be given the `NormalizeToLF` treatment separately for the same reason). It had no golden fixture at all under `internal/processor`, so its output shifted with this same bump and nothing in the test suite would have caught it either way.
+
+> **Since resolved:** `internal/processor` was deleted in #777 (packages outside the binary dependency closure), which removed the second construction path and with it this specific coverage gap. Every remaining `nao1215/markdown` call site is under `internal/converter/`. The general risk stands — the finding here is that the call-site grep is what surfaces an unfixtured path, not that this one path was special.
 
 Separately, `THIRD_PARTY_NOTICES` pins each dependency's license URL to a specific tag via `packaging/notices.tpl` (the `just notices` recipe). Nothing in CI enforces that this file tracks `go.mod`/`go.sum`. Regenerating it after this bump rewrote 26 package URLs and added one new package entry (a font license) — only one of the 26 rewrites was the bumped package — because the file had already drifted from the dependency tree independent of this PR.
 
@@ -69,7 +71,7 @@ Upstream changelogs describe *intended* changes from the maintainer's perspectiv
 - Any dependency bump — dependabot-authored or manual — where the bumped package is imported by more than a trivial number of files, or is known to construct output bytes (markdown, HTML, XML/YAML serialization, templating, string-formatting libraries).
 - Any time `go build`/`go vet`/lint pass but a golden or snapshot test fails after a dependency bump: read the fixture diff before assuming it is noise, and before running `-update` and moving on.
 - Before citing an upstream changelog claim ("fixes X", "Y now behaves correctly") as justification for skipping verification of a repo invariant such as a `GOTCHAS.md` entry — confirm the claim against the vendored module source first.
-- When a repo has more than one code path constructing the same output format (here: `internal/converter/builder` and `internal/processor/report_markdown.go`) — a fixture gap on one of them is a standing risk for every future bump of that shared library, not just this one.
+- When a repo has more than one code path constructing the same output format — a fixture gap on one of them is a standing risk for every future bump of that shared library, not just this one. That was the case here until `internal/processor` was removed in #777; re-run the call-site grep rather than assuming the single-path state still holds.
 
 ## Examples
 
@@ -100,14 +102,17 @@ git diff internal/converter/testdata/golden/
 
 ```bash
 grep -rl 'nao1215/markdown' --include='*.go' . | grep -v _test.go
+# At the time of this bump:
 # internal/converter/builder/*.go        <- has golden fixtures
-# internal/processor/report_markdown.go  <- builds markdown independently,
+# internal/processor/report_markdown.go  <- built markdown independently,
 #                                           no golden fixture, silent exposure
+# (that second path was removed in #777; run the grep again rather than
+#  trusting this list)
 ```
 
 ## Related
 
-- `GOTCHAS.md` section 10.4 ("Never Return `md.String()` or `buf.String()` Raw") — the line-ending invariant this bump could have broken but did not, and the reason `report_markdown.go` and `internal/converter/builder` both need independent `NormalizeToLF` treatment.
+- `GOTCHAS.md` section 10.4 ("Never Return `md.String()` or `buf.String()` Raw") — the line-ending invariant this bump could have broken but did not, and the reason `report_markdown.go` and `internal/converter/builder` each needed independent `NormalizeToLF` treatment while both existed.
 - `GOTCHAS.md` section 22.2 — the `\.golden\.md$` exclude in `.pre-commit-config.yaml` keeps mdformat off these fixtures, which is why golden-file diffing is the sole detection mechanism for this class of upstream formatting change.
 - `internal/converter/golden_test.go` — the fixture harness that caught this bump; the `-update` flag is documented at the top of the file.
 - `internal/converter/builder/lineendings.go` — the `renderMarkdown` helper that is the sanctioned exit point for markdown output in the builder package.

--- a/docs/solutions/workflow-issues/just-ci-check-enforces-more-than-ci.md
+++ b/docs/solutions/workflow-issues/just-ci-check-enforces-more-than-ci.md
@@ -52,8 +52,8 @@ golangci-lint = "2.13.2"
 ```
 
 ```yaml
-# .github/workflows/ci.yml:29 — what CI uses
-version: v2.12.2   # comment says "should be handled by mise ... specified here to ensure consistency"
+# .github/workflows/ci.yml — what CI uses
+version: v2.12.2   # comment said "should be handled by mise ... specified here to ensure consistency"
 ```
 
 A routine tool bump moved mise to 2.13.2 and left `ci.yml` at 2.12.2. From then on the two ran **different linters**, and 2.13.2's staticcheck reports SA1019 deprecation hits that 2.12.2 does not:
@@ -64,6 +64,8 @@ golangci-lint 2.12.2 run ./...   ->   0 issues   exit 0     # CI, same tree, sam
 ```
 
 The second pin defeats its own stated purpose: hardcoding the version to "ensure consistency" is exactly what makes it drift, because now two files must be updated in lockstep and only one of them is what developers run. A single source of truth — let the action take the version from mise — cannot skew.
+
+> **This specific skew is closed.** #819 aligned `ci.yml` to `v2.13.2`, and the workflow now carries a comment naming the hazard: *"These are two independent pins: mise drives `just lint` locally, this one drives CI. When they drift, CI and developers run different linters against the same tree and CI silently becomes the weaker gate."* Two pins still exist, so the drift can recur — the guidance below is what keeps it caught, not the current alignment.
 
 **Do not diagnose this by reasoning about invocation differences.** The obvious suspect was the `./...` argument that `just lint` passes and `golangci-lint-action` does not. That theory was wrong, and only running CI's exact version locally disproved it:
 


### PR DESCRIPTION
## Summary

Audited all 17 learnings under `docs/solutions/` against the current tree and corrected the ones that had drifted. Eight were verified accurate and left untouched; nine were updated; none needed replacing or deleting.

Of 114 path references checked across the store, every broken one pointed at `internal/processor`, removed in #777. A single package deletion accounted for the entire drift surface.

## What changed

| Doc | Correction |
| --- | --- |
| `file-split-refactor-gotchas` | Dropped the deleted package from `components` — it never appeared in the body |
| `format-dispatch-centralization` | Removed a verification-checklist item for a package that no longer exists; repointed two broken links. `AGENTS.md section 5.9b` never existed (the file has no numbered sections), and `architecture.md`'s FormatRegistry coverage now lives in `architecture/pipelines.md` |
| `pr-and-commit-message-content-standard` | The three copy-paste PR-body templates used a relative `AI_POLICY.md` link that breaks once pasted into a PR body; the doc's own prose already used the absolute URL |
| `documentation-code-drift-interface-refactoring` | Noted that the recurrence section's cited files went with the package, keeping the references as the record of what that review examined |
| `recursive-alias-resolution-dag-blowup` | The doc still opened with "unmerged as of this writing — the cited file does not exist on `main` yet". It does; `maxAliasDepth`, the per-`Resolve` memo, and node-level `dedupeSorted` are all present as described |
| `plugin-panic-recovery-audit-runchecks` | Dropped a dangling cross-reference |
| `ci-runs-on-pull-request` | `docs.yml` also runs on `pull_request`, and `copilot-setup-steps.yml` was missing from the trigger table — it is also the one workflow a bare feature-branch push can fire, so the doc's central claim needed qualifying |
| `dependency-bump-markdown-output-whitespace-drift` | The unfixtured second markdown-construction path it flagged as a standing risk no longer exists. Kept the lesson, marked the gap closed, and pointed readers at re-running the call-site grep rather than trusting the doc's file list |
| `just-ci-check-enforces-more-than-ci` | #819 closed the golangci-lint pin skew that was the doc's headline example. Two independent pins still exist, so the guidance stands; `ci.yml` now carries a comment stating the same lesson |

Considered consolidating the two red-mode WAN-exposure docs, which share a file, an issue and a PR, and rejected it — they document opposite failure directions (a false negative from port-range matching, a false positive from NAT correlation).

## CONCEPTS.md

The `Named-object reference layer` entry claimed the layer was not yet implemented and that `CommonDevice` did not expose the fields. It has since #710: `CommonDevice.NamedObjects` plus `ObjectRef` on five rule fields. Refined the entry, added the `Common device` entry both Device-model entries lean on without defining, and removed file paths and type names per the glossary's stand-on-its-own rule.

## AGENTS.md

The `Solutions` link named the store but gave a reader no way to search it. Added the categories and frontmatter fields, matching the `Concepts` line beside it.

## Test plan

- [x] `just ci-check` passes (exit 0)
- [x] `pre-commit run --files` clean and idempotent across all 11 files; `mdformat` reflow applied
- [x] Every retained claim re-verified against current code — symbol, file and line cited in the per-doc detail
- [x] Documentation-only: no Go source touched

## AI disclosure

Used Claude Code (`Claude Opus 5 (1M Context)`) to audit the store and draft these corrections. Every claim was verified against the tree, and the change was validated with `just ci-check` and `pre-commit` before push. Followed process per [`AI_POLICY.md`](https://github.com/EvilBit-Labs/opnDossier/blob/main/AI_POLICY.md).
